### PR TITLE
fix(a11y): improve landing page text contrast and focus visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ pnpm format      # prettier check
 pnpm format:write
 ```
 
+## Accessibility
+
+- Contrast target: WCAG 2.1 AA for normal text (`>= 4.5:1`).
+- Components remediated for contrast:
+  - `components/landing/StatsStrip.tsx`
+  - `components/landing/FinalCtaFooter.tsx`
+- Release gate checks:
+  - `pnpm lint`
+  - `pnpm typecheck`
+  - `pnpm build`
+  - Lighthouse accessibility (desktop and mobile) against local production server
+
+Verification snapshot (2026-02-11):
+
+- Desktop accessibility score: `95 -> 100`
+- Mobile accessibility score: `95 -> 100`
+- Failing audit delta: `color-contrast` only, `12 -> 0` failing nodes
+
 ## Environment variables
 
 `NEXT_PUBLIC_IMAGEFORGE_VERSION` is used for public version display in the UI.

--- a/components/landing/FinalCtaFooter.tsx
+++ b/components/landing/FinalCtaFooter.tsx
@@ -21,14 +21,14 @@ export function FinalCtaFooter() {
         </MotionWrap>
 
         <MotionWrap
-          className="mt-11 flex flex-wrap items-center justify-center gap-3 text-sm text-zinc-500"
+          className="mt-11 flex flex-wrap items-center justify-center gap-3 text-sm text-zinc-400"
           delayMs={200}
         >
           <a
             href="https://github.com/f-campana/imageforge"
             target="_blank"
             rel="noopener noreferrer"
-            className="transition hover:text-zinc-300"
+            className="transition hover:text-zinc-200 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
           >
             GitHub
           </a>
@@ -37,7 +37,7 @@ export function FinalCtaFooter() {
             href="https://www.npmjs.com/package/@imageforge/cli"
             target="_blank"
             rel="noopener noreferrer"
-            className="transition hover:text-zinc-300"
+            className="transition hover:text-zinc-200 focus-visible:rounded-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
           >
             npm
           </a>

--- a/components/landing/StatsStrip.tsx
+++ b/components/landing/StatsStrip.tsx
@@ -14,7 +14,7 @@ export function StatsStrip() {
           {STATS.map((stat, index) => (
             <MotionWrap key={stat.label} delayMs={index * 90}>
               <div className="panel-card h-full p-5 text-center md:p-6">
-                <p className="mb-1 font-mono text-[0.7rem] tracking-[0.16em] text-zinc-500 uppercase">
+                <p className="mb-1 font-mono text-[0.7rem] tracking-[0.16em] text-zinc-400 uppercase">
                   {stat.label}
                 </p>
                 <p
@@ -24,7 +24,7 @@ export function StatsStrip() {
                 >
                   {stat.value}
                 </p>
-                <p className="mt-1 text-sm text-zinc-500">{stat.subtext}</p>
+                <p className="mt-1 text-sm text-zinc-400">{stat.subtext}</p>
               </div>
             </MotionWrap>
           ))}


### PR DESCRIPTION
## Summary
- Improve text contrast in key landing sections (`StatsStrip`, `FinalCtaFooter`).
- Improve keyboard `focus-visible` styles for footer outbound links.
- Document accessibility verification snapshot in `README.md`.

## Verification
- Lighthouse accessibility (desktop): `95 -> 100`
- Lighthouse accessibility (mobile): `95 -> 100`
- `color-contrast` findings: `12 -> 0`

## Note
SEO work was split into a dedicated branch: `codex/seo-agent-full-suite-v1`.
