### PR TITLE
chore(site): post-release alignment and governance automation

### DIFF
--- a/.github/workflows/governance-cadence.yml
+++ b/.github/workflows/governance-cadence.yml
@@ -1,0 +1,60 @@
+name: Governance Cadence
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "15 14 * * 1"
+    - cron: "20 14 1 * *"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: governance-cadence-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  weekly-seo-review:
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '15 14 * * 1'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: 22
+
+      - name: Upsert weekly SEO governance issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          PERIOD_KEY="$(date -u +'%G-W%V')"
+          ISSUE_KIND="seo-weekly" \
+            PERIOD_KEY="$PERIOD_KEY" \
+            node scripts/governance/upsert-review-issue.mjs
+
+  monthly-claims-review:
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '20 14 1 * *'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: 22
+
+      - name: Upsert monthly claims governance issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          PERIOD_KEY="$(date -u +'%Y-%m')"
+          ISSUE_KIND="claims-monthly" \
+            PERIOD_KEY="$PERIOD_KEY" \
+            node scripts/governance/upsert-review-issue.mjs

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In non-development flows (CI, release verification, local production build check
 Example:
 
 ```bash
-NEXT_PUBLIC_IMAGEFORGE_VERSION=0.1.3
+NEXT_PUBLIC_IMAGEFORGE_VERSION=0.1.6
 NEXT_PUBLIC_SITE_URL=https://imageforge.dev
 ```
 
@@ -105,7 +105,7 @@ This command intentionally uses `NEXT_PUBLIC_SITE_URL=https://example.com` for d
 1. Push this repository to GitHub.
 2. In Vercel, create a new project and import the repository.
 3. Keep framework preset as **Next.js**.
-4. Set environment variable `NEXT_PUBLIC_IMAGEFORGE_VERSION` (optional but recommended).
+4. Set environment variables `NEXT_PUBLIC_SITE_URL` and `NEXT_PUBLIC_IMAGEFORGE_VERSION` (required for release alignment and canonical metadata parity).
 5. Deploy.
 
 Vercel build command and output settings can remain default for Next.js.

--- a/docs/pr-diff-audit-agents/claim-matrix.md
+++ b/docs/pr-diff-audit-agents/claim-matrix.md
@@ -4,19 +4,19 @@
 - Governance owner: Product + Growth + CLI maintainers
 - Baseline date: 2026-02-13
 
-| Claim                                                                          | Source location                                                                    | Evidence class                          | Volatility | Owner              | Update cadence      |
-| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- | --------------------------------------- | ---------- | ------------------ | ------------------- |
-| Build-time image optimization, not runtime transformation                      | `components/landing/Hero.tsx`, `components/landing/constants.ts`                   | CLI behavior + docs                     | Low        | CLI maintainers    | Per release         |
-| WebP/AVIF conversion support                                                   | `components/landing/constants.ts`, `app/layout.tsx`                                | CLI behavior + tests                    | Low        | CLI maintainers    | Per release         |
-| `blurDataURL` and manifest metadata support                                    | `components/landing/constants.ts`, `components/landing/ManifestExample.tsx`        | CLI behavior + tests                    | Low        | CLI maintainers    | Per release         |
-| Hash-based caching and rerun determinism                                       | `components/landing/constants.ts`, `components/landing/TerminalDemo.tsx`           | CLI behavior + tests                    | Medium     | CLI maintainers    | Per release         |
-| `--check` CI guard mode                                                        | `components/landing/constants.ts`, `components/landing/CICheckExample.tsx`         | CLI behavior + tests                    | Low        | CLI maintainers    | Per release         |
-| Comparison/pricing scenario statements                                         | `components/landing/ComparisonAndCost.tsx`, `components/landing/constants.ts`      | External references + dated assumptions | High       | Product + Growth   | Monthly             |
-| Air-gapped/local-processing compatibility statements                           | `components/landing/constants.ts`                                                  | Architectural behavior                  | Medium     | Product + Security | Quarterly           |
-| Responsive width-set semantics (requested vs effective, no upscale, width cap) | `components/landing/constants.ts`, `docs/pr-diff-audit-agents/cli-contract-pin.md` | Pending contract pin from ImageForge    | High       | CLI maintainers    | At Wave 2 + release |
+| Claim                                                                          | Source location                                                                    | Evidence class                                       | Volatility | Owner              | Update cadence                   |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- | ---------------------------------------------------- | ---------- | ------------------ | -------------------------------- |
+| Build-time image optimization, not runtime transformation                      | `components/landing/Hero.tsx`, `components/landing/constants.ts`                   | CLI behavior + docs                                  | Low        | CLI maintainers    | Per release                      |
+| WebP/AVIF conversion support                                                   | `components/landing/constants.ts`, `app/layout.tsx`                                | CLI behavior + tests                                 | Low        | CLI maintainers    | Per release                      |
+| `blurDataURL` and manifest metadata support                                    | `components/landing/constants.ts`, `components/landing/ManifestExample.tsx`        | CLI behavior + tests                                 | Low        | CLI maintainers    | Per release                      |
+| Hash-based caching and rerun determinism                                       | `components/landing/constants.ts`, `components/landing/TerminalDemo.tsx`           | CLI behavior + tests                                 | Medium     | CLI maintainers    | Per release                      |
+| `--check` CI guard mode                                                        | `components/landing/constants.ts`, `components/landing/CICheckExample.tsx`         | CLI behavior + tests                                 | Low        | CLI maintainers    | Per release                      |
+| Comparison/pricing scenario statements                                         | `components/landing/ComparisonAndCost.tsx`, `components/landing/constants.ts`      | External references + dated assumptions              | High       | Product + Growth   | Monthly                          |
+| Air-gapped/local-processing compatibility statements                           | `components/landing/constants.ts`                                                  | Architectural behavior                               | Medium     | Product + Security | Quarterly                        |
+| Responsive width-set semantics (requested vs effective, no upscale, width cap) | `components/landing/constants.ts`, `docs/pr-diff-audit-agents/cli-contract-pin.md` | Pinned to `022957c640615c3abb45d1a7e3fb4cba961be558` | High       | CLI maintainers    | At release + per contract change |
 
 ## Governance Notes
 
 1. Dated claims must include both `as-of` date and ownership.
-2. Any claim dependent on responsive width semantics remains conditional until `cli-contract-pin.md` is fully pinned.
+2. Claims dependent on responsive width semantics must stay aligned to the pinned SHA in `cli-contract-pin.md` and be re-reviewed on each CLI contract change.
 3. Source links for pricing claims must remain valid and be re-checked at each monthly review.

--- a/docs/pr-diff-audit-agents/governance-cadence.md
+++ b/docs/pr-diff-audit-agents/governance-cadence.md
@@ -1,0 +1,35 @@
+# Governance Cadence
+
+This document defines the recurring governance loop for SEO and claim integrity.
+
+## Ownership and SLA
+
+1. Default owner: `@f-campana`
+2. SLA: review and disposition each governance issue within 2 business days.
+
+## Recurring Reviews
+
+1. Weekly SEO review
+2. Monthly claims/source verification review
+
+## Automation Contract
+
+Automation runs from `.github/workflows/governance-cadence.yml` and creates issues via `scripts/governance/upsert-review-issue.mjs`.
+
+1. Weekly issue key format: `YYYY-Www` (ISO week)
+2. Monthly issue key format: `YYYY-MM`
+3. Idempotency: if an open issue for the same review type and period key exists, no new issue is created.
+
+## Review Checklist
+
+### Weekly SEO review
+
+1. Inspect latest SEO artifacts from CI and weekly workflow.
+2. Confirm `critical=0` and track medium/low advisories.
+3. Create follow-up tasks for regressions and assign owner/date.
+
+### Monthly claims/source review
+
+1. Verify pricing and external comparison claims still map to active sources.
+2. Confirm responsive-width claims remain aligned to `cli-contract-pin.md`.
+3. Update claim matrix `as-of` evidence references when source facts shift.

--- a/docs/pr-diff-audit-agents/release-note-draft.md
+++ b/docs/pr-diff-audit-agents/release-note-draft.md
@@ -4,8 +4,9 @@
 
 This update stabilizes the ImageForge landing and SEO integration stack with stronger CI guardrails and clearer claim governance. CI now enforces formatting and SEO unit tests, workflows are hardened with pinned GitHub Action SHAs and explicit permissions, and weekly SEO automation has timeout/concurrency controls. Product claims now include ownership metadata for time-sensitive pricing references, and responsive-width messaging is explicitly tied to a pinned CLI contract handshake before final claim publication.
 
-## Follow-up Before Publish
+## Post-release Verification Checklist
 
-1. Replace `PENDING_IMAGEFORGE_WAVE2_SHA` in `cli-contract-pin.md`.
-2. Confirm responsive-width contract file exists at pinned commit.
+1. Confirm npm serves `@imageforge/cli@0.1.6`.
+2. Confirm `cli-contract-pin.md` remains pinned to `022957c640615c3abb45d1a7e3fb4cba961be558` until the next contract change.
 3. Re-run strict SEO release verifier and attach report artifacts.
+4. Confirm production env has `NEXT_PUBLIC_IMAGEFORGE_VERSION=0.1.6`.

--- a/docs/pr-diff-audit-agents/seo-gate-policy.md
+++ b/docs/pr-diff-audit-agents/seo-gate-policy.md
@@ -32,3 +32,10 @@ With `NEXT_PUBLIC_SITE_URL` set:
 5. `SEO_MODE=strict pnpm seo:check` passes (no critical failures)
 
 Without `NEXT_PUBLIC_SITE_URL`, advisory checks report one critical URL-resolution failure by design.
+
+## Governance Cadence
+
+1. Weekly SEO review issue creation is automated by `.github/workflows/governance-cadence.yml`.
+2. Monthly claims/source review issue creation is automated by `.github/workflows/governance-cadence.yml`.
+3. Default owner is `@f-campana`, with review expected within 2 business days.
+4. Weekly and monthly reviews are idempotent per period key to prevent duplicate open issues.

--- a/scripts/governance/upsert-review-issue.mjs
+++ b/scripts/governance/upsert-review-issue.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function issueTemplate(kind, periodKey) {
+  if (kind === "seo-weekly") {
+    return {
+      title: `[Governance][seo-weekly] ${periodKey}`,
+      body: [
+        "Automated weekly SEO governance review.",
+        "",
+        `- Owner: @f-campana`,
+        `- SLA: 2 business days`,
+        `- Period key: ${periodKey}`,
+        "",
+        "Checklist:",
+        "1. Inspect latest SEO artifacts (`seo` CI job + weekly SEO workflow).",
+        "2. Confirm critical findings remain zero.",
+        "3. Convert notable medium/low advisories into tracked follow-up tasks.",
+      ].join("\n"),
+    };
+  }
+
+  if (kind === "claims-monthly") {
+    return {
+      title: `[Governance][claims-monthly] ${periodKey}`,
+      body: [
+        "Automated monthly claim/source governance review.",
+        "",
+        `- Owner: @f-campana`,
+        `- SLA: 2 business days`,
+        `- Period key: ${periodKey}`,
+        "",
+        "Checklist:",
+        "1. Re-verify external pricing/comparison sources used on landing.",
+        "2. Confirm responsive-width claims still align with pinned CLI contract SHA.",
+        "3. Update claim matrix evidence notes for any changed facts.",
+      ].join("\n"),
+    };
+  }
+
+  throw new Error(
+    `Unsupported ISSUE_KIND '${kind}'. Expected 'seo-weekly' or 'claims-monthly'.`,
+  );
+}
+
+async function ghRequest(url, token, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API ${response.status}: ${text}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+async function main() {
+  const token = requireEnv("GITHUB_TOKEN");
+  const repository = requireEnv("GITHUB_REPOSITORY");
+  const issueKind = requireEnv("ISSUE_KIND");
+  const periodKey = requireEnv("PERIOD_KEY");
+  const [owner, repo] = repository.split("/");
+
+  if (!owner || !repo) {
+    throw new Error(`Invalid GITHUB_REPOSITORY value: '${repository}'`);
+  }
+
+  const { title, body } = issueTemplate(issueKind, periodKey);
+
+  const listUrl = `https://api.github.com/repos/${owner}/${repo}/issues?state=open&per_page=100`;
+  const issues = await ghRequest(listUrl, token);
+  const existing = issues.find(
+    (issue) => issue.title === title && issue.pull_request === undefined,
+  );
+
+  if (existing) {
+    console.log(
+      `Issue already exists: #${existing.number} (${existing.html_url})`,
+    );
+    return;
+  }
+
+  const createUrl = `https://api.github.com/repos/${owner}/${repo}/issues`;
+  const created = await ghRequest(createUrl, token, {
+    method: "POST",
+    body: JSON.stringify({
+      title,
+      body,
+    }),
+  });
+
+  console.log(`Created issue #${created.number}: ${created.html_url}`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- align site docs to CLI release `0.1.6`
- finalize claim/release docs against pinned CLI contract SHA
- add governance cadence automation (weekly SEO + monthly claims review issue upsert)

## Changes
- update `/README.md` env/version guidance and deploy requirements
- refresh:
  - `docs/pr-diff-audit-agents/claim-matrix.md`
  - `docs/pr-diff-audit-agents/release-note-draft.md`
  - `docs/pr-diff-audit-agents/seo-gate-policy.md`
- add:
  - `docs/pr-diff-audit-agents/governance-cadence.md`
  - `.github/workflows/governance-cadence.yml`
  - `scripts/governance/upsert-review-issue.mjs`

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
- `NEXT_PUBLIC_SITE_URL=https://example.com pnpm build`
- `pnpm seo:test`
- `NEXT_PUBLIC_SITE_URL=https://example.com SEO_MODE=advisory pnpm seo:check`
