### PR TITLE
feat(animation): reduce benchmark entry density and align interactions

### DIFF
--- a/components/benchmark/BenchmarkPageContent.tsx
+++ b/components/benchmark/BenchmarkPageContent.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { MotionWrap } from "@/components/landing/MotionWrap";
+import { BENCHMARK_SEQUENCE_DELAYS_MS } from "@/lib/animation/config";
 import type { SiteBenchmarkSnapshot } from "@/lib/benchmark/types";
 
 type BenchmarkPageContentProps = {
@@ -14,12 +15,11 @@ const PROFILE_COLORS: Record<string, string> = {
   P3: "bg-cyan-300/85",
 };
 
-const BENCHMARK_CARD_INTERACTION_CLASS =
-  "transition-[border-color,background-color] duration-150 motion-safe:transition-transform motion-safe:duration-150 motion-safe:hover:-translate-y-px";
+const BENCHMARK_CARD_INTERACTION_CLASS = "ui-interact-card";
 const BENCHMARK_TABLE_ROW_INTERACTION_CLASS =
   "border-b border-white/8 transition-colors duration-150 hover:bg-white/[0.02]";
-const BENCHMARK_LINK_INTERACTION_CLASS =
-  "transition-[color,border-color,background-color] duration-150 motion-safe:transition-transform motion-safe:duration-150 motion-safe:hover:-translate-y-px";
+const BENCHMARK_CONTROL_INTERACTION_CLASS = "ui-interact-control ui-focus-ring";
+const BENCHMARK_LINK_INTERACTION_CLASS = "ui-interact-link ui-focus-ring";
 
 function formatNumber(value: number, digits = 2): string {
   return Number.isFinite(value) ? value.toFixed(digits) : "0.00";
@@ -150,7 +150,7 @@ export function BenchmarkPageContent({
               <p className="mt-6">
                 <Link
                   href="/"
-                  className={`inline-flex rounded-md border border-emerald-300/45 bg-emerald-300/10 px-4 py-2 text-sm font-semibold text-emerald-200 hover:border-emerald-200 hover:bg-emerald-300/20 hover:text-emerald-100 ${BENCHMARK_LINK_INTERACTION_CLASS}`}
+                  className={`inline-flex rounded-md border border-emerald-300/45 bg-emerald-300/10 px-4 py-2 text-sm font-semibold text-emerald-200 hover:border-emerald-200 hover:bg-emerald-300/20 hover:text-emerald-100 ${BENCHMARK_CONTROL_INTERACTION_CLASS}`}
                 >
                   Back to landing
                 </Link>
@@ -213,7 +213,11 @@ export function BenchmarkPageContent({
             </div>
           </MotionWrap>
 
-          <MotionWrap surface="benchmark" className="mt-10" delayMs={40}>
+          <MotionWrap
+            surface="benchmark"
+            className="mt-10"
+            delayMs={BENCHMARK_SEQUENCE_DELAYS_MS.summary}
+          >
             <div className="grid gap-4 md:grid-cols-3">
               <div
                 className={`panel-card h-full p-5 ${BENCHMARK_CARD_INTERACTION_CLASS}`}
@@ -269,7 +273,7 @@ export function BenchmarkPageContent({
 
       <section className="border-b border-white/10 py-16 md:py-20">
         <div className="section-shell">
-          <MotionWrap surface="benchmark">
+          <MotionWrap surface="benchmark" mode="static">
             <h2 className="text-3xl font-semibold tracking-tight text-zinc-100 md:text-4xl">
               Cold wall time
             </h2>
@@ -284,7 +288,7 @@ export function BenchmarkPageContent({
 
       <section className="border-b border-white/10 py-16 md:py-20">
         <div className="section-shell">
-          <MotionWrap surface="benchmark" delayMs={24}>
+          <MotionWrap surface="benchmark" mode="static">
             <h2 className="text-3xl font-semibold tracking-tight text-zinc-100 md:text-4xl">
               Warm p50 wall time
             </h2>
@@ -299,7 +303,10 @@ export function BenchmarkPageContent({
 
       <section className="border-b border-white/10 py-16 md:py-20">
         <div className="section-shell">
-          <MotionWrap surface="benchmark" delayMs={36}>
+          <MotionWrap
+            surface="benchmark"
+            delayMs={BENCHMARK_SEQUENCE_DELAYS_MS.deltas}
+          >
             <h2 className="text-3xl font-semibold tracking-tight text-zinc-100 md:text-4xl">
               Head vs base deltas
             </h2>
@@ -419,7 +426,10 @@ export function BenchmarkPageContent({
 
       <section className="border-b border-white/10 py-16 md:py-20">
         <div className="section-shell">
-          <MotionWrap surface="benchmark" delayMs={52}>
+          <MotionWrap
+            surface="benchmark"
+            delayMs={BENCHMARK_SEQUENCE_DELAYS_MS.throughput}
+          >
             <h2 className="text-3xl font-semibold tracking-tight text-zinc-100 md:text-4xl">
               Throughput (batch-all, warm)
             </h2>
@@ -461,7 +471,10 @@ export function BenchmarkPageContent({
 
       <section className="border-b border-white/10 py-16 md:py-20">
         <div className="section-shell">
-          <MotionWrap surface="benchmark" delayMs={68}>
+          <MotionWrap
+            surface="benchmark"
+            delayMs={BENCHMARK_SEQUENCE_DELAYS_MS.recent}
+          >
             <h2 className="text-3xl font-semibold tracking-tight text-zinc-100 md:text-4xl">
               Recent approved snapshots
             </h2>
@@ -501,7 +514,7 @@ export function BenchmarkPageContent({
                       href={entry.source.runUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={`inline-flex rounded-md border border-white/20 bg-white/[0.03] px-3 py-1.5 font-mono text-[0.68rem] tracking-[0.08em] text-zinc-200 uppercase hover:border-white/30 hover:text-zinc-100 ${BENCHMARK_LINK_INTERACTION_CLASS}`}
+                      className={`inline-flex rounded-md border border-white/20 bg-white/[0.03] px-3 py-1.5 font-mono text-[0.68rem] tracking-[0.08em] text-zinc-200 uppercase hover:border-white/30 hover:text-zinc-100 ${BENCHMARK_CONTROL_INTERACTION_CLASS}`}
                     >
                       Open run
                     </a>

--- a/lib/animation/config.ts
+++ b/lib/animation/config.ts
@@ -44,6 +44,13 @@ export const CYCLE3_TOP_HALF_BUDGET = {
   maxDistancePx: 6,
 } as const;
 
+export const BENCHMARK_SEQUENCE_DELAYS_MS = {
+  summary: 0,
+  deltas: 40,
+  throughput: 80,
+  recent: 120,
+} as const;
+
 export const TERMINAL_ANIMATION = {
   previewLines: 6,
   observerThreshold: 0.12,


### PR DESCRIPTION
## Summary
- reduce benchmark default entry density by keeping only 4 animated section wrappers
- keep benchmark hero static and convert cold/warm sections to static rendering
- standardize benchmark interactions onto shared landing tokens (`ui-interact-card`, `ui-interact-control ui-focus-ring`, `ui-interact-link ui-focus-ring`)
- replace benchmark delay magic numbers with shared sequence constants (`0/40/80/120`)

## Changed files and why
- `/Users/fabiencampana/Documents/imageforge-site/components/benchmark/BenchmarkPageContent.tsx`
  - lowered benchmark animation wrapper count by switching cold/warm sections to `mode="static"`
  - set explicit sequence delays for remaining benchmark animated sections
  - aligned benchmark controls/links/cards with shared micro-interaction utility classes
- `/Users/fabiencampana/Documents/imageforge-site/lib/animation/config.ts`
  - added `BENCHMARK_SEQUENCE_DELAYS_MS` constants to remove hard-coded stagger values

## Validation
- `pnpm format` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `NEXT_PUBLIC_SITE_URL=https://example.com pnpm build` ✅
- `NEXT_PUBLIC_SITE_URL=https://example.com pnpm seo:full -- --mode advisory` ✅ (critical=0, high=1, medium=1, low=0, score=85)
- `NEXT_PUBLIC_SITE_URL=https://example.com pnpm animation:check` ✅
  - canonical matrix generatedAt: `2026-02-18T23:56:42.494Z`
  - fixture matrix generatedAt: `2026-02-18T23:57:23.748Z`
- fixture density evidence ✅
  - `jq '[.rows[] | select(.route=="/benchmarks/latest" and .motionMode=="default") | .motionWrapCount] | add / length' .tmp/animation/matrix-fixture.json`
  - result: `4` (target `<=4`)

## Remaining risks / follow-up
- style/density scoring remains advisory; only core safety checks are blocking
- benchmark motion readability should continue to be monitored in follow-up benchmark layout changes
