### PR TITLE
fix(benchmarks): add back navigation on latest page

### DIFF
--- a/app/benchmarks/latest/page.tsx
+++ b/app/benchmarks/latest/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { BenchmarkPageContent } from "@/components/benchmark/BenchmarkPageContent";
 import {
@@ -22,6 +23,29 @@ export default function BenchmarkLatestPage() {
   return (
     <div className="relative min-h-screen overflow-x-clip bg-[var(--background)] text-[var(--foreground)]">
       <div className="site-grid-layer" aria-hidden="true" />
+      <header className="sticky top-0 z-50 border-b border-white/10 bg-[#06080d]/86 backdrop-blur-md">
+        <div className="section-shell py-4 md:py-5">
+          <div className="flex items-center justify-between gap-3">
+            <Link
+              href="/"
+              className="ui-interact-link ui-focus-ring shrink-0 font-mono text-lg font-semibold tracking-tight text-zinc-100 hover:text-white"
+            >
+              imageforge
+            </Link>
+            <div className="flex items-center gap-3">
+              <span className="hidden font-mono text-[0.68rem] tracking-[0.08em] text-zinc-500 uppercase sm:inline">
+                benchmark evidence
+              </span>
+              <Link
+                href="/"
+                className="ui-interact-control ui-focus-ring inline-flex rounded-md border border-white/20 bg-white/[0.03] px-3 py-1.5 font-mono text-[0.68rem] tracking-[0.08em] text-zinc-200 uppercase hover:border-white/30 hover:text-zinc-100"
+              >
+                Back to landing
+              </Link>
+            </div>
+          </div>
+        </div>
+      </header>
       <BenchmarkPageContent latest={latest} history={history} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add a sticky benchmark header on `/benchmarks/latest`
- add `imageforge` home link and a clear `Back to landing` control to `/`
- keep styles aligned with existing landing interaction classes/tokens

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build
