### PR TITLE
feat(analytics): add browser opt-out for owner traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ pnpm format:write
   event instrumentation and eventual PostHog expansion.
 - Custom event emission is disabled by default and gated by
   `NEXT_PUBLIC_ANALYTICS_CUSTOM_EVENTS=1`.
+- You can opt your own browser out of analytics counting by visiting any page
+  once with `?analytics=off`. To opt back in for that browser, visit with
+  `?analytics=on`.
 - Event names and planned payloads are documented in
   `docs/analytics/event-taxonomy.md`.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
-import { Analytics } from "@vercel/analytics/next";
 import { IBM_Plex_Mono, Space_Grotesk } from "next/font/google";
 
+import { VercelAnalytics } from "@/components/analytics/VercelAnalytics";
 import { resolveSiteUrl } from "@/lib/seo/site-url";
 
 import "./globals.css";
@@ -77,7 +77,7 @@ export default function RootLayout({
         className={`${headingFont.variable} ${monoFont.variable} antialiased`}
       >
         {children}
-        <Analytics mode={analyticsMode} debug={false} />
+        <VercelAnalytics mode={analyticsMode} />
       </body>
     </html>
   );

--- a/components/analytics/VercelAnalytics.tsx
+++ b/components/analytics/VercelAnalytics.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {
+  Analytics,
+  type AnalyticsProps,
+  type BeforeSend,
+} from "@vercel/analytics/next";
+
+const ANALYTICS_QUERY_PARAM = "analytics";
+const ANALYTICS_OPT_OUT_STORAGE_KEY = "imageforge.analytics.optOut";
+
+type VercelAnalyticsProps = {
+  mode: AnalyticsProps["mode"];
+};
+
+function shouldBlockAnalytics(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const queryValue = new URLSearchParams(window.location.search).get(
+      ANALYTICS_QUERY_PARAM,
+    );
+
+    if (queryValue === "off") {
+      window.localStorage.setItem(ANALYTICS_OPT_OUT_STORAGE_KEY, "1");
+    } else if (queryValue === "on") {
+      window.localStorage.removeItem(ANALYTICS_OPT_OUT_STORAGE_KEY);
+    }
+
+    return window.localStorage.getItem(ANALYTICS_OPT_OUT_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+const beforeSend: BeforeSend = (event) => {
+  if (shouldBlockAnalytics()) {
+    return null;
+  }
+
+  return event;
+};
+
+export function VercelAnalytics({ mode }: VercelAnalyticsProps) {
+  return <Analytics mode={mode} debug={false} beforeSend={beforeSend} />;
+}

--- a/docs/analytics/event-taxonomy.md
+++ b/docs/analytics/event-taxonomy.md
@@ -8,6 +8,8 @@ All events below are **planned** and are **not emitted in phase 1**.
 - Tracking in production today: pageviews only (Vercel Web Analytics).
 - Custom events: gated by `NEXT_PUBLIC_ANALYTICS_CUSTOM_EVENTS=1`.
 - Default gate value: `0` (disabled).
+- Owner browser opt-out: visit with `?analytics=off` once to stop counting
+  traffic in that browser. Re-enable with `?analytics=on`.
 
 ## Event contract
 


### PR DESCRIPTION
## Summary
- add a client-side Vercel Analytics wrapper that filters events via `beforeSend`
- support owner/browser opt-out with query-param toggles:
  - `?analytics=off` -> persist local opt-out and drop analytics events
  - `?analytics=on` -> clear local opt-out and resume event sending
- keep production-only analytics mode behavior unchanged
- document the toggle behavior in analytics docs

## Changed files
- app/layout.tsx
- components/analytics/VercelAnalytics.tsx
- README.md
- docs/analytics/event-taxonomy.md

## Validation
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm build

All commands passed locally.
