### PR TITLE
feat(analytics): add speed insights with production-only shared opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,22 @@ pnpm format:write
 
 - Vercel Web Analytics is enabled via `@vercel/analytics` in
   `app/layout.tsx`.
+- Vercel Speed Insights is enabled via `@vercel/speed-insights` in
+  `app/layout.tsx`.
 - Mode is environment-aware:
   - `production` only when `VERCEL_ENV=production`
   - `development` for local and preview environments
 - This keeps production metrics clean while avoiding free-tier noise from
   preview traffic.
+- Speed Insights is rendered only when `VERCEL_ENV=production` and uses
+  `sampleRate=1`.
 - A vendor-neutral helper lives at `lib/analytics/track-event.ts` for future
   event instrumentation and eventual PostHog expansion.
 - Custom event emission is disabled by default and gated by
   `NEXT_PUBLIC_ANALYTICS_CUSTOM_EVENTS=1`.
-- You can opt your own browser out of analytics counting by visiting any page
-  once with `?analytics=off`. To opt back in for that browser, visit with
-  `?analytics=on`.
+- You can opt your own browser out of analytics and speed insights counting by
+  visiting any page once with `?analytics=off`. To opt back in for that
+  browser, visit with `?analytics=on`.
 - Event names and planned payloads are documented in
   `docs/analytics/event-taxonomy.md`.
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,13 +2,14 @@ import type { Metadata } from "next";
 import { IBM_Plex_Mono, Space_Grotesk } from "next/font/google";
 
 import { VercelAnalytics } from "@/components/analytics/VercelAnalytics";
+import { VercelSpeedInsights } from "@/components/analytics/VercelSpeedInsights";
 import { resolveSiteUrl } from "@/lib/seo/site-url";
 
 import "./globals.css";
 
 const siteUrl = resolveSiteUrl();
-const analyticsMode =
-  process.env.VERCEL_ENV === "production" ? "production" : "development";
+const isVercelProduction = process.env.VERCEL_ENV === "production";
+const analyticsMode = isVercelProduction ? "production" : "development";
 
 const headingFont = Space_Grotesk({
   subsets: ["latin"],
@@ -78,6 +79,7 @@ export default function RootLayout({
       >
         {children}
         <VercelAnalytics mode={analyticsMode} />
+        {isVercelProduction ? <VercelSpeedInsights /> : null}
       </body>
     </html>
   );

--- a/components/analytics/VercelAnalytics.tsx
+++ b/components/analytics/VercelAnalytics.tsx
@@ -6,37 +6,14 @@ import {
   type BeforeSend,
 } from "@vercel/analytics/next";
 
-const ANALYTICS_QUERY_PARAM = "analytics";
-const ANALYTICS_OPT_OUT_STORAGE_KEY = "imageforge.analytics.optOut";
+import { shouldSuppressTelemetry } from "@/lib/analytics/browser-opt-out";
 
 type VercelAnalyticsProps = {
   mode: AnalyticsProps["mode"];
 };
 
-function shouldBlockAnalytics(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-
-  try {
-    const queryValue = new URLSearchParams(window.location.search).get(
-      ANALYTICS_QUERY_PARAM,
-    );
-
-    if (queryValue === "off") {
-      window.localStorage.setItem(ANALYTICS_OPT_OUT_STORAGE_KEY, "1");
-    } else if (queryValue === "on") {
-      window.localStorage.removeItem(ANALYTICS_OPT_OUT_STORAGE_KEY);
-    }
-
-    return window.localStorage.getItem(ANALYTICS_OPT_OUT_STORAGE_KEY) === "1";
-  } catch {
-    return false;
-  }
-}
-
 const beforeSend: BeforeSend = (event) => {
-  if (shouldBlockAnalytics()) {
+  if (shouldSuppressTelemetry()) {
     return null;
   }
 

--- a/components/analytics/VercelSpeedInsights.tsx
+++ b/components/analytics/VercelSpeedInsights.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { SpeedInsights } from "@vercel/speed-insights/next";
+
+import { shouldSuppressTelemetry } from "@/lib/analytics/browser-opt-out";
+
+export function VercelSpeedInsights() {
+  return (
+    <SpeedInsights
+      sampleRate={1}
+      debug={false}
+      beforeSend={(event) => {
+        if (shouldSuppressTelemetry()) {
+          return null;
+        }
+
+        return event;
+      }}
+    />
+  );
+}

--- a/docs/analytics/event-taxonomy.md
+++ b/docs/analytics/event-taxonomy.md
@@ -6,10 +6,12 @@ All events below are **planned** and are **not emitted in phase 1**.
 ## Status
 
 - Tracking in production today: pageviews only (Vercel Web Analytics).
+- Vercel Speed Insights is enabled in production only with `sampleRate=1`.
 - Custom events: gated by `NEXT_PUBLIC_ANALYTICS_CUSTOM_EVENTS=1`.
 - Default gate value: `0` (disabled).
 - Owner browser opt-out: visit with `?analytics=off` once to stop counting
-  traffic in that browser. Re-enable with `?analytics=on`.
+  analytics and speed insights traffic in that browser. Re-enable with
+  `?analytics=on`.
 
 ## Event contract
 

--- a/lib/analytics/browser-opt-out.ts
+++ b/lib/analytics/browser-opt-out.ts
@@ -1,0 +1,39 @@
+const ANALYTICS_QUERY_PARAM = "analytics";
+const ANALYTICS_OPT_OUT_STORAGE_KEY = "imageforge.analytics.optOut";
+
+export function applyAnalyticsOptOutFromQuery() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const queryValue = new URLSearchParams(window.location.search).get(
+      ANALYTICS_QUERY_PARAM,
+    );
+
+    if (queryValue === "off") {
+      window.localStorage.setItem(ANALYTICS_OPT_OUT_STORAGE_KEY, "1");
+    } else if (queryValue === "on") {
+      window.localStorage.removeItem(ANALYTICS_OPT_OUT_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore browser storage/query access failures and keep telemetry enabled.
+  }
+}
+
+export function isAnalyticsOptOutEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(ANALYTICS_OPT_OUT_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function shouldSuppressTelemetry(): boolean {
+  applyAnalyticsOptOutFromQuery();
+  return isAnalyticsOptOutEnabled();
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
+    "@vercel/speed-insights": "^1.3.1",
     "cheerio": "^1.1.2",
     "googleapis": "^171.4.0",
     "motion": "^12.34.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       "@vercel/analytics":
         specifier: ^1.6.1
         version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+      "@vercel/speed-insights":
+        specifier: ^1.3.1
+        version: 1.3.1(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       cheerio:
         specifier: ^1.1.2
         version: 1.2.0
@@ -1164,6 +1167,32 @@ packages:
     peerDependenciesMeta:
       "@remix-run/react":
         optional: true
+      "@sveltejs/kit":
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  "@vercel/speed-insights@1.3.1":
+    resolution:
+      {
+        integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==,
+      }
+    peerDependencies:
+      "@sveltejs/kit": ^1 || ^2
+      next: ">= 13"
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: ">= 4"
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       "@sveltejs/kit":
         optional: true
       next:
@@ -4488,6 +4517,11 @@ snapshots:
     optional: true
 
   "@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)":
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+
+  "@vercel/speed-insights@1.3.1(next@16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)":
     optionalDependencies:
       next: 16.1.6(@babel/core@7.29.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3


### PR DESCRIPTION
## Summary
- add Vercel Speed Insights integration to the root layout
- collect Speed Insights in production only (`VERCEL_ENV=production`)
- introduce shared browser opt-out helpers reused by Web Analytics and Speed Insights (`?analytics=off` / `?analytics=on`)
- keep custom event gating unchanged and document the combined telemetry behavior

## Changed files
- `app/layout.tsx`
- `components/analytics/VercelAnalytics.tsx`
- `components/analytics/VercelSpeedInsights.tsx`
- `lib/analytics/browser-opt-out.ts`
- `README.md`
- `docs/analytics/event-taxonomy.md`
- `package.json`
- `pnpm-lock.yaml`

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

All commands passed locally.
