### PR TITLE
chore(ci): enforce workflow action pinning

### DIFF
--- a/.github/workflows/animation-safety.yml
+++ b/.github/workflows/animation-safety.yml
@@ -19,15 +19,15 @@ jobs:
       BASE_URL: http://127.0.0.1:3205
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload animation matrix artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: animation-matrix
           path: .tmp/animation/*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,21 @@ permissions:
   contents: read
 
 jobs:
+  workflow-action-pinning:
+    name: workflow-action-pinning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: 22
+
+      - name: Validate workflow action pinning
+        run: node scripts/security/check-workflow-action-pinning.mjs
+
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -40,15 +55,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -89,15 +104,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm
@@ -113,15 +128,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint PR title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "animation:matrix": "node --experimental-strip-types scripts/animation/collect-matrix.mts",
     "animation:safety": "node --experimental-strip-types scripts/animation/assert-core-safety.mts",
     "animation:check": "bash scripts/animation/run-check.sh",
+    "check:workflow-action-pinning": "node scripts/security/check-workflow-action-pinning.mjs",
     "format": "prettier --check .",
     "format:write": "prettier --write ."
   },

--- a/scripts/security/check-workflow-action-pinning.mjs
+++ b/scripts/security/check-workflow-action-pinning.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const WORKFLOWS_DIR = path.join(ROOT, ".github", "workflows");
+const PINNED_REF_PATTERN = /^[0-9a-f]{40}$/;
+
+function readWorkflowFiles(dir) {
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Workflow directory not found: ${dir}`);
+  }
+
+  return fs
+    .readdirSync(dir)
+    .filter(
+      (fileName) => fileName.endsWith(".yml") || fileName.endsWith(".yaml"),
+    )
+    .sort()
+    .map((fileName) => path.join(dir, fileName));
+}
+
+function collectViolations(filePath) {
+  const lines = fs.readFileSync(filePath, "utf-8").split(/\r?\n/u);
+  const violations = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const match = line.match(/^\s*uses:\s*([^\s#]+)\s*(?:#.*)?$/u);
+    if (!match) {
+      continue;
+    }
+
+    const value = match[1].trim();
+    if (value.startsWith("./") || value.startsWith("docker://")) {
+      continue;
+    }
+
+    const atIndex = value.lastIndexOf("@");
+    if (atIndex <= 0 || atIndex === value.length - 1) {
+      violations.push({
+        filePath,
+        line: index + 1,
+        uses: value,
+        reason: "missing ref",
+      });
+      continue;
+    }
+
+    const ref = value.slice(atIndex + 1);
+    if (!PINNED_REF_PATTERN.test(ref)) {
+      violations.push({
+        filePath,
+        line: index + 1,
+        uses: value,
+        reason: "non-pinned ref",
+      });
+    }
+  }
+
+  return violations;
+}
+
+function main() {
+  const files = readWorkflowFiles(WORKFLOWS_DIR);
+  const violations = files.flatMap((filePath) => collectViolations(filePath));
+
+  if (violations.length === 0) {
+    console.log(
+      `Workflow action pinning check passed (${files.length.toString()} files).`,
+    );
+    return;
+  }
+
+  console.error("Workflow action pinning violations detected:");
+  for (const violation of violations) {
+    const relativePath = path.relative(ROOT, violation.filePath);
+    console.error(
+      `- ${relativePath}:${violation.line.toString()} (${violation.reason}) uses: ${violation.uses}`,
+    );
+  }
+
+  process.exitCode = 1;
+}
+
+main();


### PR DESCRIPTION
## Summary
- pin all remaining floating GitHub Action refs to full SHAs
- add `scripts/security/check-workflow-action-pinning.mjs` policy check
- add `workflow-action-pinning` CI job to enforce the policy on every PR/push

## Validation
- pnpm run check:workflow-action-pinning
- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm run build
