### PR TITLE
test(ci): add site fault-injection advisory pilot

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -57,6 +57,17 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           exit 0
 
+      - name: Run fault-injection pilot (advisory)
+        id: fault_injection
+        run: |
+          set +e
+          mkdir -p .tmp/fault-injection
+          pnpm test:fault-injection > .tmp/fault-injection/output.log 2>&1
+          status=$?
+          cat .tmp/fault-injection/output.log
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
       - name: Run E2E tests (advisory)
         id: e2e
         run: |
@@ -96,6 +107,7 @@ jobs:
             test-results/visual/**
             .tmp/lhci/**
             coverage/**
+            .tmp/fault-injection/**
           if-no-files-found: warn
 
       - name: Publish advisory summary
@@ -103,6 +115,7 @@ jobs:
         run: |
           unit_status="${{ steps.unit.outputs.status }}"
           unit_coverage_status="${{ steps.unit_coverage.outputs.status }}"
+          fault_injection_status="${{ steps.fault_injection.outputs.status }}"
           e2e_status="${{ steps.e2e.outputs.status }}"
           visual_status="${{ steps.visual.outputs.status }}"
           lhci_status="${{ steps.lhci.outputs.status }}"
@@ -122,6 +135,7 @@ jobs:
             echo "| --- | ---: | --- |"
             echo "| Vitest unit | ${unit_status:-unknown} | $(format_status "${unit_status:-1}") |"
             echo "| Vitest coverage | ${unit_coverage_status:-unknown} | $(format_status "${unit_coverage_status:-1}") |"
+            echo "| Fault-injection pilot | ${fault_injection_status:-unknown} | $(format_status "${fault_injection_status:-1}") |"
             echo "| Playwright e2e | ${e2e_status:-unknown} | $(format_status "${e2e_status:-1}") |"
             echo "| Playwright visual | ${visual_status:-unknown} | $(format_status "${visual_status:-1}") |"
             echo "| Lighthouse CI | ${lhci_status:-unknown} | $(format_status "${lhci_status:-1}") |"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "seo:full": "node scripts/seo/run.mjs --suite full --mode advisory",
     "seo:check": "node scripts/seo/run.mjs --suite full --mode ${SEO_MODE:-advisory}",
     "audit:prod:reliable": "node scripts/security/audit-prod-deps.mjs",
+    "test:fault-injection": "node --test scripts/security/__tests__/*.test.mjs",
     "seo:test": "node --test scripts/seo/__tests__/*.test.mjs",
     "benchmark:test": "node --test scripts/benchmark/__tests__/*.test.mjs",
     "animation:matrix": "node --experimental-strip-types scripts/animation/collect-matrix.mts",

--- a/scripts/security/__tests__/audit-prod-deps.test.mjs
+++ b/scripts/security/__tests__/audit-prod-deps.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+
+const ROOT = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  "..",
+  "..",
+);
+const AUDIT_SCRIPT = path.join(ROOT, "security", "audit-prod-deps.mjs");
+
+function makeBinDir(tempDir) {
+  const binDir = path.join(tempDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  return { binDir };
+}
+
+function writePnpmStub(binDir, scriptBody) {
+  const pnpmPath = path.join(binDir, "pnpm");
+  writeFileSync(pnpmPath, scriptBody, { encoding: "utf-8", mode: 0o755 });
+}
+
+test("audit wrapper fails closed when pnpm audit reports high vulnerabilities", () => {
+  const tempDir = mkdtempSync(
+    path.join(tmpdir(), "imageforge-site-audit-fi-vuln-"),
+  );
+  const { binDir } = makeBinDir(tempDir);
+
+  writePnpmStub(
+    binDir,
+    `#!/bin/sh
+if [ "$1" = "audit" ]; then
+  echo '{"metadata":{"vulnerabilities":{"high":1,"critical":0}}}'
+  exit 1
+fi
+
+echo "unexpected pnpm args: $*" >&2
+exit 2
+`,
+  );
+
+  const result = spawnSync("node", [AUDIT_SCRIPT], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Security vulnerabilities detected by pnpm audit/,
+  );
+});
+
+test("audit wrapper fails closed when primary and fallback scanners are unavailable", () => {
+  const tempDir = mkdtempSync(
+    path.join(tmpdir(), "imageforge-site-audit-fi-unavail-"),
+  );
+  const { binDir } = makeBinDir(tempDir);
+
+  writePnpmStub(
+    binDir,
+    `#!/bin/sh
+if [ "$1" = "audit" ]; then
+  echo "permission denied" >&2
+  exit 1
+fi
+
+if [ "$1" = "list" ]; then
+  echo "list unavailable" >&2
+  exit 1
+fi
+
+echo "unexpected pnpm args: $*" >&2
+exit 2
+`,
+  );
+
+  const result = spawnSync("node", [AUDIT_SCRIPT], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Fallback scanner unavailable/);
+});


### PR DESCRIPTION
## Summary
- add injected-failure tests for the production dependency audit wrapper
- add a non-blocking fault-injection advisory step to quality gates
- upload fault-injection logs as CI artifacts for triage

## Validation
- pnpm test:fault-injection
- pnpm run check:ci