### PR TITLE
fix(seo): make H1 audit render-aware

### DIFF
--- a/scripts/seo/__tests__/site-url.test.mjs
+++ b/scripts/seo/__tests__/site-url.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { resolveSiteUrlFromEnv } from "../config.mjs";
+import {
+  resolveAuditBaseUrlFromEnv,
+  resolveSiteUrlFromEnv,
+} from "../config.mjs";
 
 test("resolveSiteUrlFromEnv uses NEXT_PUBLIC_SITE_URL when valid", () => {
   const result = resolveSiteUrlFromEnv({
@@ -64,4 +67,24 @@ test("resolveSiteUrlFromEnv reports missing URL when no sources exist", () => {
   assert.equal(result.url, null);
   assert.equal(result.source, null);
   assert.ok(result.error?.includes("No canonical site URL found"));
+});
+
+test("resolveAuditBaseUrlFromEnv returns null when not configured", () => {
+  const result = resolveAuditBaseUrlFromEnv({});
+  assert.equal(result, null);
+});
+
+test("resolveAuditBaseUrlFromEnv returns normalized absolute URL", () => {
+  const result = resolveAuditBaseUrlFromEnv({
+    SEO_AUDIT_BASE_URL: "https://imageforge.dev",
+  });
+
+  assert.equal(result, "https://imageforge.dev/");
+});
+
+test("resolveAuditBaseUrlFromEnv throws when URL is invalid", () => {
+  assert.throws(
+    () => resolveAuditBaseUrlFromEnv({ SEO_AUDIT_BASE_URL: "not-a-url" }),
+    /SEO_AUDIT_BASE_URL is present but invalid/,
+  );
 });

--- a/scripts/seo/__tests__/technical.test.mjs
+++ b/scripts/seo/__tests__/technical.test.mjs
@@ -159,3 +159,39 @@ test("evaluateRouteH1Coverage warns when a route has zero or multiple H1 entries
   assert.match(result.evidence, /\/=2h1/);
   assert.match(result.evidence, /\/benchmarks\/latest=0h1/);
 });
+
+test("evaluateRouteH1Coverage includes rendered-route evidence when render mode is used", () => {
+  const result = evaluateRouteH1Coverage([
+    {
+      route: "/",
+      h1Count: 1,
+      sourceFile: "app/page.tsx",
+      auditedFileCount: 0,
+      auditMode: "rendered",
+      auditTarget: "https://imageforge.dev/",
+      auditError: null,
+    },
+  ]);
+
+  assert.equal(result.status, "pass");
+  assert.match(result.evidence, /mode=rendered/);
+  assert.match(result.evidence, /url=https:\/\/imageforge\.dev\//);
+});
+
+test("evaluateRouteH1Coverage marks source fallback explicitly when render mode is unavailable", () => {
+  const result = evaluateRouteH1Coverage([
+    {
+      route: "/",
+      h1Count: 1,
+      sourceFile: "app/page.tsx",
+      auditedFileCount: 4,
+      auditMode: "source-fallback",
+      auditTarget: null,
+      auditError: null,
+    },
+  ]);
+
+  assert.equal(result.status, "pass");
+  assert.match(result.evidence, /mode=source-fallback/);
+  assert.match(result.evidence, /files=4/);
+});

--- a/scripts/seo/config.mjs
+++ b/scripts/seo/config.mjs
@@ -21,6 +21,7 @@ const ConfigSchema = z.object({
   suite: SeoSuiteSchema,
   locale: z.string().min(1),
   competitorUrls: z.array(z.string().url()),
+  auditBaseUrl: z.string().url().nullable(),
   rootDir: z.string().min(1),
   appDir: z.string().min(1),
   componentsDir: z.string().min(1),
@@ -162,6 +163,22 @@ export function resolveSiteUrlFromEnv(env = process.env) {
   });
 }
 
+export function resolveAuditBaseUrlFromEnv(env = process.env) {
+  const raw = env.SEO_AUDIT_BASE_URL?.trim();
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = parseSiteUrlCandidate(raw);
+  if (!parsed) {
+    throw new Error(
+      "SEO_AUDIT_BASE_URL is present but invalid. Use an absolute http(s) URL.",
+    );
+  }
+
+  return parsed.toString();
+}
+
 export function loadConfig(argv = process.argv.slice(2), env = process.env) {
   const args = parseCliArgs(argv);
   const mode = args.mode ?? SeoModeSchema.parse(env.SEO_MODE ?? "advisory");
@@ -190,6 +207,7 @@ export function loadConfig(argv = process.argv.slice(2), env = process.env) {
     suite,
     locale,
     competitorUrls,
+    auditBaseUrl: resolveAuditBaseUrlFromEnv(env),
     rootDir,
     appDir: path.join(rootDir, "app"),
     componentsDir: path.join(rootDir, "components"),

--- a/scripts/seo/technical.mjs
+++ b/scripts/seo/technical.mjs
@@ -280,6 +280,94 @@ function collectRouteSourceGraph(entryFilePath, fileContentsByPath, rootDir) {
   return [...visited];
 }
 
+function countHeadingOne(html) {
+  return [...String(html).matchAll(/<h1\b/giu)].length;
+}
+
+async function collectRenderedRouteH1Entries(
+  routeEntries,
+  auditBaseUrl,
+  fetchImpl = fetch,
+) {
+  return Promise.all(
+    routeEntries.map(async (entry) => {
+      const targetUrl = new URL(entry.route, auditBaseUrl).toString();
+
+      try {
+        const response = await fetchImpl(targetUrl, {
+          signal: AbortSignal.timeout(8000),
+        });
+
+        if (!response.ok) {
+          return {
+            route: entry.route,
+            h1Count: 0,
+            sourceFile: entry.sourceFile,
+            auditedFileCount: 0,
+            auditMode: "rendered",
+            auditTarget: targetUrl,
+            auditError: `HTTP ${response.status}`,
+          };
+        }
+
+        const html = await response.text();
+        return {
+          route: entry.route,
+          h1Count: countHeadingOne(html),
+          sourceFile: entry.sourceFile,
+          auditedFileCount: 0,
+          auditMode: "rendered",
+          auditTarget: targetUrl,
+          auditError: null,
+        };
+      } catch (error) {
+        return {
+          route: entry.route,
+          h1Count: 0,
+          sourceFile: entry.sourceFile,
+          auditedFileCount: 0,
+          auditMode: "rendered",
+          auditTarget: targetUrl,
+          auditError: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }),
+  );
+}
+
+function collectSourceRouteH1Entries(
+  routeEntries,
+  fileContentsByPath,
+  rootDir,
+) {
+  return routeEntries.map((entry) => {
+    const routeSourceGraph = collectRouteSourceGraph(
+      entry.pageFilePath,
+      fileContentsByPath,
+      rootDir,
+    );
+    const auditedFiles = routeSourceGraph.filter((sourceFilePath) =>
+      includeInH1Audit(rootDir, sourceFilePath),
+    );
+    const h1Count = auditedFiles.reduce(
+      (count, sourceFilePath) =>
+        count +
+        (fileContentsByPath.get(sourceFilePath)?.match(/<h1\b/g)?.length ?? 0),
+      0,
+    );
+
+    return {
+      route: entry.route,
+      h1Count,
+      sourceFile: entry.sourceFile,
+      auditedFileCount: auditedFiles.length,
+      auditMode: "source-fallback",
+      auditTarget: null,
+      auditError: null,
+    };
+  });
+}
+
 export function evaluateRouteH1Coverage(routeEntries) {
   if (routeEntries.length === 0) {
     return {
@@ -291,10 +379,16 @@ export function evaluateRouteH1Coverage(routeEntries) {
 
   const invalidEntries = routeEntries.filter((entry) => entry.h1Count !== 1);
   const evidence = routeEntries
-    .map(
-      (entry) =>
-        `${entry.route}=${entry.h1Count}h1 (source=${entry.sourceFile}, files=${entry.auditedFileCount})`,
-    )
+    .map((entry) => {
+      if (entry.auditMode === "rendered") {
+        const errorSegment = entry.auditError
+          ? `, error=${entry.auditError}`
+          : "";
+        return `${entry.route}=${entry.h1Count}h1 (source=${entry.sourceFile}, mode=rendered, url=${entry.auditTarget}${errorSegment})`;
+      }
+
+      return `${entry.route}=${entry.h1Count}h1 (source=${entry.sourceFile}, mode=source-fallback, files=${entry.auditedFileCount})`;
+    })
     .join("; ");
 
   if (invalidEntries.length === 0) {
@@ -307,8 +401,7 @@ export function evaluateRouteH1Coverage(routeEntries) {
 
   return {
     status: "warn",
-    message:
-      "Some indexable routes do not resolve to exactly one H1 in audited source.",
+    message: "Some indexable routes do not resolve to exactly one H1.",
     evidence,
   };
 }
@@ -503,37 +596,28 @@ export async function runTechnicalChecks(config) {
   const pageFiles = await listFilesRecursively(config.appDir, (filePath) =>
     /page\.tsx$/.test(filePath),
   );
-  const routeH1Entries = pageFiles
+  const routePageEntries = pageFiles
     .map((pageFilePath) => {
       const route = resolveRouteFromFile(config.appDir, pageFilePath);
       if (!route) {
         return null;
       }
 
-      const routeSourceGraph = collectRouteSourceGraph(
+      return {
+        route,
         pageFilePath,
+        sourceFile: path.relative(config.rootDir, pageFilePath),
+      };
+    })
+    .filter((entry) => entry && !isDynamicRoute(entry.route));
+
+  const routeH1Entries = config.auditBaseUrl
+    ? await collectRenderedRouteH1Entries(routePageEntries, config.auditBaseUrl)
+    : collectSourceRouteH1Entries(
+        routePageEntries,
         fileContentsByPath,
         config.rootDir,
       );
-      const auditedFiles = routeSourceGraph.filter((sourceFilePath) =>
-        includeInH1Audit(config.rootDir, sourceFilePath),
-      );
-      const h1Count = auditedFiles.reduce(
-        (count, sourceFilePath) =>
-          count +
-          (fileContentsByPath.get(sourceFilePath)?.match(/<h1\b/g)?.length ??
-            0),
-        0,
-      );
-
-      return {
-        route,
-        h1Count,
-        sourceFile: path.relative(config.rootDir, pageFilePath),
-        auditedFileCount: auditedFiles.length,
-      };
-    })
-    .filter(Boolean);
 
   const h1Coverage = evaluateRouteH1Coverage(routeH1Entries);
   checks.push(


### PR DESCRIPTION
## Summary
- add `SEO_AUDIT_BASE_URL` config support with strict absolute URL validation
- switch technical H1 auditing to rendered-route HTML when audit base URL is provided
- keep explicit source-fallback mode when render audit is unavailable
- extend SEO unit tests for render/fallback evidence and audit URL parsing

## Validation
- `pnpm seo:test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format`
