### PR TITLE
feat(governance): enforce pricing freshness in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,42 @@ jobs:
       - name: Run SEO unit tests
         run: pnpm seo:test
 
+  pricing-freshness:
+    name: pricing-freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pricing freshness unit tests
+        run: node --test scripts/governance/__tests__/check-pricing-freshness.test.mjs
+
+      - name: Run pricing freshness gate
+        run: pnpm governance:pricing:freshness
+
+      - name: Upload pricing freshness artifact
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: pricing-freshness
+          path: .tmp/governance/pricing-freshness.json
+          if-no-files-found: error
+
   benchmark-test:
     name: benchmark-test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ pnpm seo:content # content SEO checks
 pnpm seo:offpage # off-page/public SEO checks
 pnpm seo:full    # full SEO checks (includes optional GSC adapter)
 pnpm seo:check   # CI-oriented SEO check (mode from SEO_MODE)
+pnpm governance:pricing:freshness # fail-closed pricing freshness check
 pnpm seo:test    # SEO script unit tests
 pnpm format      # prettier check
 pnpm format:write
@@ -151,6 +152,7 @@ pnpm check:ci
 ```
 
 This command intentionally uses `NEXT_PUBLIC_SITE_URL=https://example.com` for deterministic local parity.
+CI also runs `pnpm governance:pricing:freshness` as a required freshness gate.
 
 ## Deploy to Vercel
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "seo:full": "node scripts/seo/run.mjs --suite full --mode advisory",
     "seo:check": "node scripts/seo/run.mjs --suite full --mode ${SEO_MODE:-advisory}",
     "seo:check:deterministic": "node scripts/seo/run.mjs --suite tech --mode ${SEO_MODE:-advisory} && node scripts/seo/run.mjs --suite content --mode ${SEO_MODE:-advisory}",
+    "governance:pricing:freshness": "node scripts/governance/check-pricing-freshness.mjs",
     "audit:prod:reliable": "node scripts/security/audit-prod-deps.mjs",
     "test:fault-injection": "node --test scripts/security/__tests__/*.test.mjs",
     "seo:test": "node --test scripts/seo/__tests__/*.test.mjs",

--- a/scripts/governance/__tests__/check-pricing-freshness.test.mjs
+++ b/scripts/governance/__tests__/check-pricing-freshness.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  evaluatePricingFreshness,
+  parsePricingAsOf,
+  runCheckPricingFreshness,
+} from "../check-pricing-freshness.mjs";
+
+test("parsePricingAsOf extracts PRICING_AS_OF constant", () => {
+  const source = 'export const PRICING_AS_OF = "February 20, 2026";';
+  const parsed = parsePricingAsOf(source);
+  assert.equal(parsed, "February 20, 2026");
+});
+
+test("runCheckPricingFreshness passes when pricing date is within threshold", async () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "imageforge-pricing-fresh-"));
+  const constantsPath = path.join(tempDir, "constants.ts");
+  const outputPath = path.join(tempDir, "pricing-freshness.json");
+
+  writeFileSync(
+    constantsPath,
+    'export const PRICING_AS_OF = "February 20, 2026";\n',
+    "utf8",
+  );
+
+  const report = await runCheckPricingFreshness({
+    constantsPath,
+    outputPath,
+    maxAgeDays: 45,
+    now: new Date("2026-02-23T00:00:00.000Z"),
+  });
+
+  assert.equal(report.status, "pass");
+  assert.equal(report.reason, "fresh");
+  assert.equal(report.ageDays, 3);
+
+  const persisted = JSON.parse(await readFile(outputPath, "utf8"));
+  assert.equal(persisted.status, "pass");
+});
+
+test("runCheckPricingFreshness fails when pricing date is stale", async () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "imageforge-pricing-stale-"));
+  const constantsPath = path.join(tempDir, "constants.ts");
+  const outputPath = path.join(tempDir, "pricing-freshness.json");
+
+  writeFileSync(
+    constantsPath,
+    'export const PRICING_AS_OF = "January 1, 2026";\n',
+    "utf8",
+  );
+
+  const report = await runCheckPricingFreshness({
+    constantsPath,
+    outputPath,
+    maxAgeDays: 45,
+    now: new Date("2026-02-23T00:00:00.000Z"),
+  });
+
+  assert.equal(report.status, "fail");
+  assert.equal(report.reason, "stale_pricing_as_of");
+  assert.equal(report.ageDays, 53);
+});
+
+test("runCheckPricingFreshness fails when PRICING_AS_OF is invalid", async () => {
+  const tempDir = mkdtempSync(
+    path.join(tmpdir(), "imageforge-pricing-invalid-"),
+  );
+  const constantsPath = path.join(tempDir, "constants.ts");
+
+  writeFileSync(
+    constantsPath,
+    'export const PRICING_AS_OF = "not-a-date";\n',
+    "utf8",
+  );
+
+  const report = await runCheckPricingFreshness({
+    constantsPath,
+    outputPath: path.join(tempDir, "pricing-freshness.json"),
+    maxAgeDays: 45,
+    now: new Date("2026-02-23T00:00:00.000Z"),
+  });
+
+  assert.equal(report.status, "fail");
+  assert.equal(report.reason, "invalid_pricing_as_of");
+});
+
+test("runCheckPricingFreshness fails when PRICING_AS_OF is missing", async () => {
+  const tempDir = mkdtempSync(
+    path.join(tmpdir(), "imageforge-pricing-missing-"),
+  );
+  const constantsPath = path.join(tempDir, "constants.ts");
+
+  writeFileSync(
+    constantsPath,
+    'export const PRICING_OWNER = "Team";\n',
+    "utf8",
+  );
+
+  const report = await runCheckPricingFreshness({
+    constantsPath,
+    outputPath: path.join(tempDir, "pricing-freshness.json"),
+    maxAgeDays: 45,
+    now: new Date("2026-02-23T00:00:00.000Z"),
+  });
+
+  assert.equal(report.status, "fail");
+  assert.equal(report.reason, "missing_pricing_as_of");
+});
+
+test("evaluatePricingFreshness returns missing reason for blank values", () => {
+  const result = evaluatePricingFreshness({
+    pricingAsOf: "",
+    maxAgeDays: 45,
+    now: new Date("2026-02-23T00:00:00.000Z"),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "missing_pricing_as_of");
+});

--- a/scripts/governance/check-pricing-freshness.mjs
+++ b/scripts/governance/check-pricing-freshness.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_MAX_AGE_DAYS = 45;
+const DEFAULT_CONSTANTS_RELATIVE_PATH = "components/landing/constants.ts";
+const DEFAULT_OUTPUT_RELATIVE_PATH = ".tmp/governance/pricing-freshness.json";
+
+function parseArgs(argv) {
+  const args = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      continue;
+    }
+
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+
+    args[key] = next;
+    index += 1;
+  }
+
+  return args;
+}
+
+function toInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isInteger(parsed) ? parsed : fallback;
+}
+
+export function parsePricingAsOf(constantsSource) {
+  const match = String(constantsSource).match(
+    /export const PRICING_AS_OF\s*=\s*"([^"]+)";/u,
+  );
+  return match?.[1] ?? "";
+}
+
+function ageInDays(thenDate, nowDate) {
+  const ageMs = nowDate.getTime() - thenDate.getTime();
+  return Math.max(0, Math.floor(ageMs / DAY_MS));
+}
+
+export function evaluatePricingFreshness({
+  pricingAsOf,
+  maxAgeDays,
+  now = new Date(),
+}) {
+  if (!pricingAsOf) {
+    return {
+      ok: false,
+      reason: "missing_pricing_as_of",
+      parsedDate: null,
+      ageDays: null,
+      message: "PRICING_AS_OF is missing.",
+    };
+  }
+
+  const parsedDate = new Date(pricingAsOf);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return {
+      ok: false,
+      reason: "invalid_pricing_as_of",
+      parsedDate: null,
+      ageDays: null,
+      message: `PRICING_AS_OF is invalid: '${pricingAsOf}'.`,
+    };
+  }
+
+  const ageDays = ageInDays(parsedDate, now);
+  if (ageDays > maxAgeDays) {
+    return {
+      ok: false,
+      reason: "stale_pricing_as_of",
+      parsedDate: parsedDate.toISOString(),
+      ageDays,
+      message: `PRICING_AS_OF is stale (${ageDays.toString()} days old; threshold ${maxAgeDays.toString()} days).`,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: "fresh",
+    parsedDate: parsedDate.toISOString(),
+    ageDays,
+    message: `PRICING_AS_OF is fresh (${ageDays.toString()} days old; threshold ${maxAgeDays.toString()} days).`,
+  };
+}
+
+export async function runCheckPricingFreshness({
+  rootDir = process.cwd(),
+  constantsPath = path.join(rootDir, DEFAULT_CONSTANTS_RELATIVE_PATH),
+  outputPath = path.join(rootDir, DEFAULT_OUTPUT_RELATIVE_PATH),
+  maxAgeDays = DEFAULT_MAX_AGE_DAYS,
+  now = new Date(),
+} = {}) {
+  const constantsAbsolutePath = path.resolve(constantsPath);
+  const outputAbsolutePath = path.resolve(outputPath);
+
+  let constantsSource = "";
+  try {
+    constantsSource = await readFile(constantsAbsolutePath, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const report = {
+      version: "1.0.0",
+      generatedAt: now.toISOString(),
+      status: "fail",
+      reason: "constants_read_failed",
+      message: `Unable to read pricing constants file: ${message}`,
+      maxAgeDays,
+      pricingAsOf: "",
+      parsedDate: null,
+      ageDays: null,
+      constantsPath: constantsAbsolutePath,
+    };
+
+    await mkdir(path.dirname(outputAbsolutePath), { recursive: true });
+    await writeFile(outputAbsolutePath, `${JSON.stringify(report, null, 2)}\n`);
+    return report;
+  }
+
+  const pricingAsOf = parsePricingAsOf(constantsSource);
+  const evaluation = evaluatePricingFreshness({
+    pricingAsOf,
+    maxAgeDays,
+    now,
+  });
+
+  const report = {
+    version: "1.0.0",
+    generatedAt: now.toISOString(),
+    status: evaluation.ok ? "pass" : "fail",
+    reason: evaluation.reason,
+    message: evaluation.message,
+    maxAgeDays,
+    pricingAsOf,
+    parsedDate: evaluation.parsedDate,
+    ageDays: evaluation.ageDays,
+    constantsPath: constantsAbsolutePath,
+  };
+
+  await mkdir(path.dirname(outputAbsolutePath), { recursive: true });
+  await writeFile(outputAbsolutePath, `${JSON.stringify(report, null, 2)}\n`);
+  return report;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const now = args.now ? new Date(String(args.now)) : new Date();
+  if (Number.isNaN(now.getTime())) {
+    throw new Error("--now must be a valid date string.");
+  }
+
+  const maxAgeDays = toInteger(args["max-age-days"], DEFAULT_MAX_AGE_DAYS);
+  if (maxAgeDays < 1) {
+    throw new Error("--max-age-days must be a positive integer.");
+  }
+
+  const report = await runCheckPricingFreshness({
+    constantsPath:
+      typeof args.constants === "string"
+        ? path.resolve(args.constants)
+        : undefined,
+    outputPath:
+      typeof args.output === "string" ? path.resolve(args.output) : undefined,
+    maxAgeDays,
+    now,
+  });
+
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+  if (report.status !== "pass") {
+    process.exitCode = 1;
+  }
+}
+
+const isMainModule =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add `scripts/governance/check-pricing-freshness.mjs` for deterministic pricing age validation
- fail closed when `PRICING_AS_OF` is missing, invalid, or older than threshold (default 45 days)
- emit machine-readable output to `.tmp/governance/pricing-freshness.json`
- add governance unit tests for pass/stale/invalid/missing scenarios
- add required CI job `pricing-freshness` and document new script in README

## Validation
- `node --test scripts/governance/__tests__/check-pricing-freshness.test.mjs`
- `pnpm governance:pricing:freshness`
- `pnpm check:ci`
