### PR TITLE
feat(site): add docs and contact routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ This site intentionally describes ImageForge as:
 - `--json` machine-readable run report to stdout
 - `imageforge.json` manifest output by default
 
+## First-party routes
+
+- `/` landing page
+- `/benchmarks/latest` benchmark evidence page
+- `/docs` quick-start documentation entrypoint
+- `/contact` support and feedback entrypoint
+
 ## Local setup
 
 ```bash

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "ImageForge Contact | Support and Feedback",
+  description:
+    "Contact and feedback entry points for ImageForge CLI support, bug reports, feature requests, and security reporting.",
+  alternates: {
+    canonical: "/contact",
+  },
+};
+
+export default function ContactPage() {
+  return (
+    <div className="relative min-h-screen overflow-x-clip bg-[var(--background)] text-[var(--foreground)]">
+      <div className="site-grid-layer" aria-hidden="true" />
+      <main className="section-shell py-20 md:py-28">
+        <h1 className="max-w-3xl text-4xl leading-tight font-semibold tracking-tight text-zinc-100 md:text-6xl">
+          Contact and feedback
+        </h1>
+        <p className="mt-5 max-w-3xl text-base leading-relaxed text-zinc-300 md:text-lg">
+          Use these channels for support, bug reports, roadmap discussion, and
+          coordinated security disclosure.
+        </p>
+
+        <section className="mt-10 grid gap-4 md:grid-cols-2">
+          <a
+            href="https://github.com/f-campana/imageforge/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ui-interact-control ui-focus-ring rounded-2xl border border-white/10 bg-white/5 p-5 hover:border-white/20 hover:bg-white/10"
+          >
+            <h2 className="text-lg font-semibold text-zinc-100">
+              Bug reports and feature requests
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-zinc-300">
+              Open or search GitHub issues for product feedback and engineering
+              support.
+            </p>
+          </a>
+
+          <a
+            href="https://github.com/f-campana/imageforge/blob/main/SECURITY.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ui-interact-control ui-focus-ring rounded-2xl border border-white/10 bg-white/5 p-5 hover:border-white/20 hover:bg-white/10"
+          >
+            <h2 className="text-lg font-semibold text-zinc-100">
+              Security reporting
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-zinc-300">
+              Follow the coordinated disclosure process documented in
+              SECURITY.md.
+            </p>
+          </a>
+        </section>
+
+        <section className="mt-8 rounded-2xl border border-white/10 bg-white/5 p-5">
+          <h2 className="text-lg font-semibold text-zinc-100">Documentation</h2>
+          <p className="mt-2 text-sm leading-relaxed text-zinc-300">
+            Start with first-party docs, then follow links to full GitHub
+            technical references and changelog details.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link
+              href="/docs"
+              className="ui-interact-control ui-focus-ring inline-flex rounded-md border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-zinc-200 hover:border-white/35 hover:bg-white/10 hover:text-white"
+            >
+              Open docs
+            </Link>
+            <Link
+              href="/"
+              className="ui-interact-control ui-focus-ring inline-flex rounded-md border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-zinc-200 hover:border-white/35 hover:bg-white/10 hover:text-white"
+            >
+              Back to landing
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "ImageForge Docs | Getting Started",
+  description:
+    "Quick-start docs for ImageForge CLI: install, run, CI check mode, and benchmark evidence references.",
+  alternates: {
+    canonical: "/docs",
+  },
+};
+
+export default function DocsPage() {
+  return (
+    <div className="relative min-h-screen overflow-x-clip bg-[var(--background)] text-[var(--foreground)]">
+      <div className="site-grid-layer" aria-hidden="true" />
+      <main className="section-shell py-20 md:py-28">
+        <h1 className="max-w-3xl text-4xl leading-tight font-semibold tracking-tight text-zinc-100 md:text-6xl">
+          ImageForge docs
+        </h1>
+        <p className="mt-5 max-w-3xl text-base leading-relaxed text-zinc-300 md:text-lg">
+          ImageForge is a build-time image optimization CLI for WebP/AVIF
+          derivatives, blur placeholders, and deterministic CI freshness checks.
+        </p>
+
+        <section className="mt-10 space-y-5 rounded-2xl border border-white/10 bg-white/5 p-6">
+          <h2 className="text-xl font-semibold text-zinc-100">Quick start</h2>
+          <pre className="overflow-x-auto rounded-lg border border-white/10 bg-black/30 p-4 font-mono text-sm text-zinc-100">
+            <code>{`npx @imageforge/cli ./public/images\nimageforge ./public/images --check`}</code>
+          </pre>
+          <p className="text-sm leading-relaxed text-zinc-300">
+            Use <code className="font-mono text-zinc-100">--check</code> in CI
+            to fail when image outputs are stale, and run without{" "}
+            <code className="font-mono text-zinc-100">--check</code> to apply
+            updates.
+          </p>
+        </section>
+
+        <section className="mt-8 space-y-3 text-sm text-zinc-300">
+          <h2 className="text-xl font-semibold text-zinc-100">References</h2>
+          <ul className="space-y-2">
+            <li>
+              <a
+                href="https://github.com/f-campana/imageforge#readme"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ui-interact-link ui-focus-ring hover:text-emerald-300"
+              >
+                GitHub README
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://github.com/f-campana/imageforge/blob/main/CHANGELOG.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ui-interact-link ui-focus-ring hover:text-emerald-300"
+              >
+                Changelog
+              </a>
+            </li>
+            <li>
+              <Link
+                href="/benchmarks/latest"
+                className="ui-interact-link ui-focus-ring hover:text-emerald-300"
+              >
+                Benchmark evidence
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/contact"
+                className="ui-interact-link ui-focus-ring hover:text-emerald-300"
+              >
+                Contact
+              </Link>
+            </li>
+          </ul>
+        </section>
+
+        <div className="mt-10">
+          <Link
+            href="/"
+            className="ui-interact-control ui-focus-ring inline-flex rounded-md border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-zinc-200 hover:border-white/35 hover:bg-white/10 hover:text-white"
+          >
+            Back to landing
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,5 +18,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "daily",
       priority: 0.8,
     },
+    {
+      url: new URL("/docs", siteUrl).toString(),
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
+      url: new URL("/contact", siteUrl).toString(),
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
   ];
 }

--- a/components/landing/FinalCtaFooter.tsx
+++ b/components/landing/FinalCtaFooter.tsx
@@ -23,12 +23,17 @@ export function FinalCtaFooter() {
         <MotionWrap className="mt-5 text-center" delayMs={160}>
           <div className="flex flex-wrap items-center justify-center gap-3 text-sm text-zinc-400">
             <a
-              href="https://github.com/f-campana/imageforge#readme"
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/docs"
               className="ui-interact-link ui-focus-ring hover:text-emerald-300"
             >
               Docs
+            </a>
+            <span>·</span>
+            <a
+              href="/contact"
+              className="ui-interact-link ui-focus-ring hover:text-emerald-300"
+            >
+              Contact
             </a>
             <span>·</span>
             <a
@@ -86,7 +91,7 @@ export function FinalCtaFooter() {
             @imageforge/cli v{IMAGEFORGE_VERSION}
           </span>
           <span>·</span>
-          <span className="font-mono">Node &gt;= 22</span>
+          <span className="font-mono">Node &gt;= 20</span>
         </MotionWrap>
       </div>
     </section>

--- a/components/landing/HeaderNav.tsx
+++ b/components/landing/HeaderNav.tsx
@@ -28,6 +28,18 @@ export function HeaderNav() {
               ))}
             </div>
             <a
+              href="/docs"
+              className="ui-interact-link ui-focus-ring hover:text-zinc-100"
+            >
+              Docs
+            </a>
+            <a
+              href="/contact"
+              className="ui-interact-link ui-focus-ring hover:text-zinc-100"
+            >
+              Contact
+            </a>
+            <a
               href="https://github.com/f-campana/imageforge"
               target="_blank"
               rel="noopener noreferrer"

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -42,12 +42,16 @@ export function Hero() {
               Get Started
             </a>
             <a
-              href="https://github.com/f-campana/imageforge"
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/docs"
               className="ui-interact-control ui-focus-ring inline-flex items-center rounded-md border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-zinc-200 hover:border-white/35 hover:bg-white/10 hover:text-white focus-visible:border-white/35 focus-visible:bg-white/10"
             >
-              Read Docs (GitHub)
+              Read Docs
+            </a>
+            <a
+              href="/contact"
+              className="ui-interact-control ui-focus-ring inline-flex items-center rounded-md border border-white/20 bg-white/5 px-4 py-2 text-sm font-medium text-zinc-200 hover:border-white/35 hover:bg-white/10 hover:text-white focus-visible:border-white/35 focus-visible:bg-white/10"
+            >
+              Contact
             </a>
           </div>
         </MotionWrap>

--- a/tests/e2e/landing-and-benchmark.smoke.spec.ts
+++ b/tests/e2e/landing-and-benchmark.smoke.spec.ts
@@ -15,6 +15,12 @@ test("landing page renders hero, CTA, and package-manager tabs", async ({
   await expect(
     heroSection.getByRole("link", { name: /Get Started/i }),
   ).toBeVisible();
+  await expect(
+    heroSection.getByRole("link", { name: /Read Docs/i }),
+  ).toBeVisible();
+  await expect(
+    heroSection.getByRole("link", { name: /Contact/i }),
+  ).toBeVisible();
 
   await expect(
     heroSection.getByRole("tablist", { name: /Package managers/i }),
@@ -28,6 +34,20 @@ test("landing page renders hero, CTA, and package-manager tabs", async ({
   await heroSection.getByRole("tab", { name: "bun" }).click();
   await expect(
     heroSection.getByText("bun add -g @imageforge/cli"),
+  ).toBeVisible();
+});
+
+test("docs and contact routes render expected primary headings", async ({
+  page,
+}) => {
+  await page.goto("/docs");
+  await expect(
+    page.getByRole("heading", { level: 1, name: /ImageForge docs/i }),
+  ).toBeVisible();
+
+  await page.goto("/contact");
+  await expect(
+    page.getByRole("heading", { level: 1, name: /Contact and feedback/i }),
   ).toBeVisible();
 });
 
@@ -64,7 +84,7 @@ test.describe("mobile benchmark surface", () => {
 test("security headers are present on landing and benchmark routes", async ({
   page,
 }) => {
-  for (const route of ["/", "/benchmarks/latest"]) {
+  for (const route of ["/", "/benchmarks/latest", "/docs", "/contact"]) {
     const response = await page.goto(route);
     expect(response).not.toBeNull();
     const headers = response!.headers();


### PR DESCRIPTION
## Summary
- add first-party `/docs` and `/contact` routes with route metadata and single H1 structure
- wire docs/contact discoverability links from landing hero, header nav, and footer
- extend sitemap with docs/contact URLs
- align displayed CLI runtime floor in landing footer to Node `>=20`
- extend Playwright smoke coverage for docs/contact route rendering and header checks

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm seo:test
- pnpm check:ci
- pnpm test:e2e
