### PR TITLE
fix(governance): refresh pricing freshness date

### DIFF
--- a/components/landing/constants.ts
+++ b/components/landing/constants.ts
@@ -67,8 +67,8 @@ export type NavItem = {
 export const IMAGEFORGE_VERSION =
   process.env.NEXT_PUBLIC_IMAGEFORGE_VERSION ?? "local-dev";
 
-export const EXAMPLE_TIMESTAMP = "2026-04-06T09:30:00.000Z";
-export const PRICING_AS_OF = "April 6, 2026";
+export const EXAMPLE_TIMESTAMP = "2026-05-29T09:30:00.000Z";
+export const PRICING_AS_OF = "May 29, 2026";
 export const PRICING_OWNER = "ImageForge Maintainers (Product + Growth)";
 const BENCHMARK_INPUT_MB = formatMegabytes(
   BENCHMARK_EVIDENCE.sampleSet.inputBytes,


### PR DESCRIPTION
## Summary
- Refresh landing example timestamp and PRICING_AS_OF to May 29, 2026.
- Restores the pricing freshness gate, which was failing on main because the prior date was 53 days old.

## Validation
- pnpm governance:pricing:freshness
- pnpm lint && pnpm typecheck && pnpm build
