### PR TITLE
fix(seo): allow local non-ci site url fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 NEXT_PUBLIC_IMAGEFORGE_VERSION=
 NEXT_PUBLIC_SITE_URL=https://your-domain.example
-# Non-dev builds and SEO checks require NEXT_PUBLIC_SITE_URL to resolve.
+# CI/deployment builds and SEO checks require NEXT_PUBLIC_SITE_URL to resolve.
+# Local non-CI builds fall back to http://localhost:3000 when unset.
 SEO_MODE=advisory
 SEO_LOCALE=en-US
 SEO_COMPETITOR_URLS=

--- a/lib/seo/site-url.ts
+++ b/lib/seo/site-url.ts
@@ -5,6 +5,24 @@ type ResolveSiteUrlOptions = {
   fallbackUrl?: string | URL;
 };
 
+function isTruthyFlag(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+function canUseLocalFallbackOutsideDevelopment(): boolean {
+  // Keep CI/deployment environments strict while allowing local checks to run.
+  const isCiLike =
+    isTruthyFlag(process.env.CI) || isTruthyFlag(process.env.GITHUB_ACTIONS);
+  const isVercelLike = isTruthyFlag(process.env.VERCEL);
+
+  return !isCiLike && !isVercelLike;
+}
+
 function parseAbsoluteHttpUrl(value: string): URL | null {
   try {
     const url = new URL(value);
@@ -92,6 +110,10 @@ export function resolveSiteUrl(options: ResolveSiteUrlOptions = {}): URL {
   }
 
   if (process.env.NODE_ENV === "development") {
+    return new URL(DEFAULT_LOCAL_URL);
+  }
+
+  if (canUseLocalFallbackOutsideDevelopment()) {
     return new URL(DEFAULT_LOCAL_URL);
   }
 

--- a/tests/unit/lib/seo/site-url.test.ts
+++ b/tests/unit/lib/seo/site-url.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveSiteUrl } from "@/lib/seo/site-url";
+
+const ENV_KEYS = [
+  "CI",
+  "GITHUB_ACTIONS",
+  "NEXT_PUBLIC_SITE_URL",
+  "NODE_ENV",
+  "SITE_URL",
+  "VERCEL",
+  "VERCEL_PROJECT_PRODUCTION_URL",
+  "VERCEL_URL",
+] as const;
+
+type EnvKey = (typeof ENV_KEYS)[number];
+
+const originalEnv = new Map<EnvKey, string | undefined>();
+
+function setNodeEnv(value: string): void {
+  setEnv("NODE_ENV", value);
+}
+
+function setEnv(key: EnvKey, value: string): void {
+  Reflect.set(process.env, key, value);
+}
+
+function deleteEnv(key: EnvKey): void {
+  Reflect.deleteProperty(process.env, key);
+}
+
+describe("resolveSiteUrl", () => {
+  beforeEach(() => {
+    originalEnv.clear();
+    for (const key of ENV_KEYS) {
+      originalEnv.set(key, process.env[key]);
+      deleteEnv(key);
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv.get(key);
+      if (value === undefined) {
+        deleteEnv(key);
+      } else {
+        setEnv(key, value);
+      }
+    }
+  });
+
+  it("uses NEXT_PUBLIC_SITE_URL when configured", () => {
+    setEnv("NEXT_PUBLIC_SITE_URL", "https://imageforge.dev");
+    setNodeEnv("production");
+
+    expect(resolveSiteUrl().toString()).toBe("https://imageforge.dev/");
+  });
+
+  it("falls back to localhost for local non-CI production checks", () => {
+    setNodeEnv("production");
+
+    expect(resolveSiteUrl().toString()).toBe("http://localhost:3000/");
+  });
+
+  it("keeps CI production checks strict when no URL is configured", () => {
+    setEnv("CI", "true");
+    setNodeEnv("production");
+
+    expect(() => resolveSiteUrl()).toThrow(/Unable to resolve site URL/u);
+  });
+
+  it("keeps Vercel production checks strict when no URL is configured", () => {
+    setEnv("VERCEL", "1");
+    setNodeEnv("production");
+
+    expect(() => resolveSiteUrl()).toThrow(/Unable to resolve site URL/u);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow runtime SEO site URL resolution to fall back to http://localhost:3000 for local non-CI production checks when no canonical URL is configured.
- Keep CI, GitHub Actions, and Vercel environments strict when URL env vars are missing.
- Update .env.example guidance and add resolver unit tests.

## Validation
- pnpm test:unit -- tests/unit/lib/seo/site-url.test.ts
- pnpm lint && pnpm typecheck && pnpm build
