### PR TITLE
docs(responsive): add landing responsive reference pack

### DIFF
--- a/.codex/skills/responsive-agent/SKILL.md
+++ b/.codex/skills/responsive-agent/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: responsive-agent
+description: Landing-focused responsive analysis workflow for ImageForge with advisory-first performance, accessibility, and SEO risk scoring.
+---
+
+# Responsive Agent
+
+Use this skill when a request mentions responsive analysis, viewport regressions, mobile behavior, or responsive performance/accessibility/SEO tradeoffs.
+
+## Scope
+
+Default scope is landing-focused:
+
+- `/Users/fabiencampana/Documents/imageforge-site/app/page.tsx`
+- `/Users/fabiencampana/Documents/imageforge-site/components/landing/*`
+- `/Users/fabiencampana/Documents/imageforge-site/app/globals.css`
+
+## Canonical References
+
+1. Audit reference:
+   `/Users/fabiencampana/Documents/imageforge-site/docs/responsive-agent/landing-responsive-reference.md`
+2. Current baseline register:
+   `/Users/fabiencampana/Documents/imageforge-site/docs/responsive-agent/landing-responsive-risk-register.md`
+3. Checklist:
+   `references/checklist.md`
+4. Severity rubric:
+   `references/severity-rubric.md`
+5. Output contract:
+   `references/output-contract.md`
+
+## Default Workflow
+
+1. Load the canonical reference and checklist.
+2. Run baseline command set:
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `NEXT_PUBLIC_SITE_URL=https://example.com pnpm build`
+   - `NEXT_PUBLIC_SITE_URL=https://example.com pnpm seo:full -- --mode advisory`
+3. Inspect landing files for responsive behavior by viewport matrix and anti-pattern catalog.
+4. Score each finding with the severity rubric.
+5. Output findings strictly using the output contract.
+6. Cross-check recommendations against existing SEO pipeline constraints (`scripts/seo/*`) and current product messaging boundaries.
+
+## Constraints
+
+1. Documentation and analysis first.
+2. Do not implement code changes unless the user explicitly asks for implementation.
+3. In cycle 1, treat all findings as advisory recommendations, even when severity is high/critical.
+
+## Repository Alignment
+
+1. Keep guidance compatible with existing metadata/canonical/schema behavior in `app/layout.tsx`, `app/page.tsx`, `lib/seo/*`.
+2. Preserve ImageForge messaging scope from `README.md` and landing component copy.
+3. Keep responsive-width semantics aligned with:
+   `/Users/fabiencampana/Documents/ImageForge/docs/product/responsive-widths-contract.md`
+
+## Output Expectations
+
+Every audit response should include:
+
+1. `ResponsiveAuditSummary`
+2. `ResponsiveFinding[]` entries with explicit viewport impact, evidence, and verification steps
+3. Advisory-first recommendation status labels

--- a/.codex/skills/responsive-agent/references/checklist.md
+++ b/.codex/skills/responsive-agent/references/checklist.md
@@ -1,0 +1,92 @@
+# Responsive Audit Checklist (Landing, Advisory Cycle 1)
+
+## 1. Preflight
+
+1. Confirm scope:
+   - `app/page.tsx`
+   - `components/landing/*`
+   - `app/globals.css`
+2. Load:
+   - `docs/responsive-agent/landing-responsive-reference.md`
+   - `docs/responsive-agent/landing-responsive-risk-register.md`
+   - `references/severity-rubric.md`
+   - `references/output-contract.md`
+3. Confirm audit mode is advisory-first.
+
+## 2. Baseline Commands
+
+Run in order:
+
+```bash
+pnpm lint
+pnpm typecheck
+NEXT_PUBLIC_SITE_URL=https://example.com pnpm build
+NEXT_PUBLIC_SITE_URL=https://example.com pnpm seo:full -- --mode advisory
+```
+
+Record pass/fail and notable warnings for the final report.
+
+## 3. Viewport Matrix Checks
+
+Check portrait widths: `320, 360, 375, 390, 412, 768, 1024, 1280, 1440`.
+
+Check landscape where interactions differ: `568x320, 667x375, 812x375`.
+
+For each viewport, verify:
+
+1. No forced 2D page scrolling.
+2. Primary CTA discoverability and usability.
+3. Nav discoverability.
+4. Keyboard reachability/focus visibility.
+5. No responsive branch content parity drift.
+
+## 4. Performance Checks
+
+1. Evaluate potential CWV risk for responsive behavior:
+   - LCP <= 2.5s target
+   - INP <= 200ms target
+   - CLS <= 0.1 target
+2. Confirm responsive media sizing strategy is coherent with layout slots.
+3. Confirm no avoidable layout-shift from breakpoint transitions.
+4. Review motion density and paint-heavy effects for mobile constraints.
+
+## 5. Accessibility Checks
+
+1. Reflow at 320 CSS px and 400% zoom without forced 2D scrolling.
+2. Touch target minimum guidance applied to primary interactive controls.
+3. Full keyboard equivalence for primary interactions.
+4. `prefers-reduced-motion` behavior verified in both CSS and JS paths.
+5. Coarse pointer/no-hover usability checks.
+
+## 6. SEO Checks
+
+1. Mobile and desktop content parity (claims, links, and meaning).
+2. Metadata parity unaffected by responsive presentation.
+3. Structured data parity unaffected by viewport/hydration conditions.
+4. No critical content hidden behind interaction-only lazy loading.
+5. Internal link consistency across responsive branches.
+
+## 7. Hotspot Pass (Repo-Specific)
+
+At minimum, inspect:
+
+- `components/landing/HeaderNav.tsx`
+- `components/landing/ComparisonAndCost.tsx`
+- `components/landing/TerminalDemo.tsx`
+- `components/landing/InstallCommands.tsx`
+- `components/landing/CopyButton.tsx`
+- `app/globals.css`
+
+## 8. Reporting
+
+1. Produce findings using `ResponsiveFinding` schema.
+2. Produce summary using `ResponsiveAuditSummary` schema.
+3. Mark all recommendations as advisory in cycle 1.
+4. Include verification steps for each finding.
+
+## 9. Exit Criteria
+
+1. Every identified issue has severity + confidence.
+2. Every recommendation includes clear verification steps.
+3. No recommendation conflicts with current `scripts/seo/*` expectations.
+4. Report is formatted exactly per output contract.

--- a/.codex/skills/responsive-agent/references/output-contract.md
+++ b/.codex/skills/responsive-agent/references/output-contract.md
@@ -1,0 +1,128 @@
+# Responsive Agent Output Contract
+
+Use this contract for all responsive audit outputs.
+
+## Format Requirements
+
+1. Always output a single summary block followed by a flat list of findings.
+2. Every finding must include all required fields.
+3. In cycle 1, set `status` to `advisory` for every finding.
+4. Keep IDs stable across reruns when the same underlying issue persists.
+
+## Types
+
+### ResponsiveFinding
+
+Required fields:
+
+- `id` (`string`): stable identifier, format `resp-<area>-<nnn>`
+- `category` (`"layout" | "interaction" | "media" | "motion" | "seo" | "a11y" | "performance" | "content-parity"`)
+- `severity` (`"critical" | "high" | "medium" | "low"`)
+- `confidence` (`number`, `0..1`)
+- `viewport` (`string`): impacted viewport range(s)
+- `files` (`string[]`): absolute or repo-resolvable paths
+- `evidence` (`string`): concise, reproducible observation
+- `user_impact` (`string`)
+- `perf_impact` (`string`)
+- `seo_impact` (`string`)
+- `a11y_impact` (`string`)
+- `fix_direction` (`string`): implementation direction, not full patch
+- `verification_steps` (`string[]`)
+- `status` (`"advisory" | "proposed-gate" | "gated"`)
+
+### ResponsiveAuditSummary
+
+Required fields:
+
+- `scope` (`string`)
+- `mode` (`"advisory" | "strict"`)
+- `totals` (`object`): `critical`, `high`, `medium`, `low`, `overall`
+- `affected_areas` (`string[]`)
+- `blocking_recommendations` (`string[]`)
+- `advisory_recommendations` (`string[]`)
+- `commands_run` (`string[]`)
+- `notes` (`string[]`)
+
+## Markdown Report Shape
+
+```md
+## Responsive Audit Summary
+
+- Scope: ...
+- Mode: advisory
+- Totals: critical=X, high=Y, medium=Z, low=W
+- Affected areas: ...
+- Commands run: ...
+
+## Findings
+
+1. [SEVERITY] <title> (`id`)
+
+- Category: ...
+- Viewport: ...
+- Files: ...
+- Evidence: ...
+- User impact: ...
+- Perf impact: ...
+- SEO impact: ...
+- A11y impact: ...
+- Fix direction: ...
+- Verification:
+  - ...
+  - ...
+- Status: advisory
+```
+
+## JSON Example
+
+```json
+{
+  "summary": {
+    "scope": "landing-focused",
+    "mode": "advisory",
+    "totals": {
+      "critical": 0,
+      "high": 1,
+      "medium": 2,
+      "low": 1,
+      "overall": 4
+    },
+    "affected_areas": ["navigation", "content-parity", "interaction"],
+    "blocking_recommendations": [],
+    "advisory_recommendations": [
+      "Add explicit mobile nav with section-link parity.",
+      "Reduce horizontal interaction dependency in command surfaces."
+    ],
+    "commands_run": [
+      "pnpm lint",
+      "pnpm typecheck",
+      "NEXT_PUBLIC_SITE_URL=https://example.com pnpm build",
+      "NEXT_PUBLIC_SITE_URL=https://example.com pnpm seo:full -- --mode advisory"
+    ],
+    "notes": ["Cycle 1 is advisory-only."]
+  },
+  "findings": [
+    {
+      "id": "resp-nav-001",
+      "category": "interaction",
+      "severity": "high",
+      "confidence": 0.86,
+      "viewport": "320-767",
+      "files": [
+        "/Users/fabiencampana/Documents/imageforge-site/components/landing/HeaderNav.tsx"
+      ],
+      "evidence": "Primary section links are hidden below md with no explicit mobile menu implementation.",
+      "user_impact": "Mobile users may miss navigation pathways.",
+      "perf_impact": "Neutral direct impact; indirect impact via increased exploratory scrolling.",
+      "seo_impact": "Reduced internal-link discoverability consistency on mobile presentation.",
+      "a11y_impact": "Potential keyboard/touch discoverability gap.",
+      "fix_direction": "Add a mobile navigation pattern with keyboard and touch parity.",
+      "verification_steps": [
+        "Check 320-412 portrait and 667x375 landscape.",
+        "Verify all section links are reachable via keyboard and touch."
+      ],
+      "status": "advisory"
+    }
+  ]
+}
+```

--- a/.codex/skills/responsive-agent/references/severity-rubric.md
+++ b/.codex/skills/responsive-agent/references/severity-rubric.md
@@ -1,0 +1,84 @@
+# Responsive Severity Rubric
+
+Cycle mode: Advisory-first (cycle 1)
+
+This rubric defines how to classify responsive findings by severity and confidence.
+
+## Severity Levels
+
+### Critical
+
+Use when any of the following is true:
+
+1. Primary task completion is blocked for a common mobile viewport.
+2. Severe accessibility failure on core interactions (for example, inaccessible primary navigation or CTA paths).
+3. Responsive behavior causes major SEO discoverability loss (critical links/content unavailable in mobile presentation).
+4. Responsive behavior introduces likely severe CWV regression (for example, persistent major CLS from layout shifts).
+
+Expected action: first-fix candidate. In cycle 1 this remains advisory, not auto-gating.
+
+### High
+
+Use when there is substantial user impact but not full task blocking:
+
+1. Core flows have high friction on common viewport ranges.
+2. Material parity drift risk between responsive branches.
+3. Likely measurable CWV degradation risk affecting user experience or ranking signals.
+4. Significant keyboard/touch usability degradation on important controls.
+
+Expected action: early-fix priority in first implementation batch.
+
+### Medium
+
+Use when issue is noticeable and recurring but workaround exists:
+
+1. Interaction friction on narrow widths.
+2. Localized content parity risk.
+3. Potential but not clearly severe CWV risk.
+4. Target-size/focus/motion concerns with partial mitigation already present.
+
+Expected action: queued after critical/high items.
+
+### Low
+
+Use when issue is minor polish or edge-case behavior:
+
+1. Cosmetic or non-blocking responsive inconsistency.
+2. Low-probability edge viewport behavior.
+3. Minimal measurable user impact expected.
+
+Expected action: backlog and batch with adjacent work.
+
+## Confidence Scoring
+
+Use `0..1` confidence scale:
+
+- `0.90-1.00`: confirmed with direct evidence plus reproducible behavior across relevant viewports.
+- `0.75-0.89`: strong static/dynamic evidence, minor unvalidated assumptions remain.
+- `0.50-0.74`: plausible issue with partial evidence, requires validation pass.
+- `<0.50`: speculative; do not recommend implementation before validation.
+
+## Impact Axes (Must Be Recorded)
+
+For each finding, explicitly assess:
+
+1. `user_impact`
+2. `perf_impact`
+3. `seo_impact`
+4. `a11y_impact`
+
+A finding can be high/critical even with neutral impact on one axis if overall harm is strong.
+
+## Tie-Break Rules
+
+When two findings share severity, prioritize:
+
+1. Broader viewport impact first.
+2. Direct conversion-path impact first.
+3. Multi-axis harm (`user + a11y` or `user + seo`) over single-axis harm.
+
+## Advisory-First Rule (Cycle 1)
+
+1. All findings must use `status: advisory`.
+2. `critical` in cycle 1 means urgent recommendation, not merge blocking.
+3. Do not promote to `proposed-gate` or `gated` until explicitly requested.

--- a/docs/responsive-agent/landing-responsive-reference.md
+++ b/docs/responsive-agent/landing-responsive-reference.md
@@ -1,0 +1,283 @@
+# Landing Responsive Reference
+
+Date: 2026-02-13
+Scope mode: Landing-focused
+Enforcement mode: Advisory-first (cycle 1)
+
+## Purpose
+
+Define where and how responsive behavior should be applied on the ImageForge landing page, and how to assess responsive risks across performance, accessibility, and SEO before implementation.
+
+This document is the canonical reference for future responsive audits and implementation planning.
+
+## Scope and Intent
+
+In scope:
+
+- `/Users/fabiencampana/Documents/imageforge-site/app/page.tsx`
+- `/Users/fabiencampana/Documents/imageforge-site/components/landing/*`
+- `/Users/fabiencampana/Documents/imageforge-site/app/globals.css`
+
+Out of scope for cycle 1:
+
+- Non-landing routes
+- Runtime production telemetry changes
+- Code implementation changes
+
+## Responsive Usage Model
+
+Responsive behavior must be evaluated in five dimensions, not just CSS breakpoints.
+
+1. Layout responsiveness
+
+- Reflow and spacing should adapt without horizontal page scrolling at narrow widths.
+- Primary reading and CTA order should remain stable across viewport sizes.
+
+2. Interaction responsiveness
+
+- Navigation and action controls should remain discoverable and usable across pointer types and viewport changes.
+- Keyboard access and focus visibility must remain equivalent to pointer access.
+
+3. Media responsiveness
+
+- Images and media should size and load appropriately for viewport width and DPR.
+- Aspect ratio and reserved space should prevent layout shifts.
+
+4. Motion responsiveness
+
+- Motion should scale down for constrained devices and respect reduced motion preference.
+- Animation should not delay access to primary content or CTA actions.
+
+5. Content parity responsiveness
+
+- Mobile and desktop experiences must keep equivalent meaning, core content, links, metadata, and structured data.
+- Responsive variants may change presentation, not factual coverage.
+
+## Viewport Matrix (Required During Audit)
+
+Use these CSS viewport widths in portrait by default:
+
+- 320
+- 360
+- 375
+- 390
+- 412
+- 768
+- 1024
+- 1280
+- 1440
+
+Landscape checks are required where interaction patterns differ:
+
+- 568x320
+- 667x375
+- 812x375
+
+For each viewport, verify:
+
+- No unexpected 2D page scroll
+- CTA visibility/discoverability
+- Nav discoverability
+- Keyboard focus visibility
+- No content loss from `hidden`/alternate markup branches
+
+## Performance Guardrails (Advisory, Cycle 1)
+
+Target thresholds:
+
+- LCP <= 2.5s
+- INP <= 200ms
+- CLS <= 0.1
+
+Responsive performance rules:
+
+1. Above-the-fold responsiveness
+
+- Do not delay hero headline/body/primary CTA visibility behind JS-only behavior.
+
+2. Responsive media delivery
+
+- Ensure rendered image slot sizes align with responsive source selection.
+- Prefer explicit responsive sizing semantics for image components.
+
+3. Layout shift prevention
+
+- Reserve media and dynamic block space so breakpoint transitions do not introduce avoidable CLS.
+
+4. Motion and paint cost
+
+- Avoid heavy large-area effects that increase paint cost on low-end mobile GPUs.
+- Keep reveal animations sparse and disabled/reduced under reduced-motion preference.
+
+5. Main-thread pressure
+
+- Avoid large numbers of concurrent observers/timers that scale poorly on small devices.
+
+## Accessibility Guardrails
+
+1. Reflow and zoom
+
+- Meet WCAG reflow expectations at 320 CSS px and 400% zoom without forced 2D page scrolling.
+
+2. Touch target minimums
+
+- Interactive targets should satisfy WCAG 2.2 target size guidance (minimum 24x24 CSS px).
+
+3. Keyboard and focus parity
+
+- Every primary action available by pointer must be reachable by keyboard.
+- Focus indicators must remain visible at all breakpoints.
+
+4. Reduced motion
+
+- Honor `prefers-reduced-motion` in CSS and JS behavior.
+- Disable non-essential animation and cursor effects for reduced-motion users.
+
+5. Pointer modality checks
+
+- Validate usability for coarse pointers and no-hover environments.
+
+## SEO Guardrails Under Responsive Behavior
+
+1. Mobile/desktop content parity
+
+- Ensure mobile variants preserve equivalent copy intent and internal links.
+- Avoid maintaining materially different claim content between breakpoint-specific branches.
+
+2. Metadata parity
+
+- Responsive presentation must not alter canonical, title/description, Open Graph, Twitter, robots, or sitemap behavior.
+
+3. Structured data parity
+
+- JSON-LD emitted for homepage must remain independent of viewport or hydration-only conditions.
+
+4. Crawlable lazy loading
+
+- Critical content and links must not require user interaction (click/tap/swipe) to become discoverable.
+
+5. Internal link consistency
+
+- Breakpoint-specific nav variants must retain stable crawlable anchor/link pathways.
+
+## Responsive Anti-Pattern Catalog
+
+1. Hidden critical nav on mobile
+
+- Symptom: desktop nav items removed without a usable mobile replacement.
+- Risk: discoverability loss, crawl path reduction, weaker engagement.
+
+2. Duplicated markup drift
+
+- Symptom: separate mobile and desktop structures drift in copy, sources, links, or factual claims.
+- Risk: inconsistent messaging, maintenance risk, SEO parity regressions.
+
+3. Fixed-height dense blocks on small screens
+
+- Symptom: min-height or fixed-height sections consume disproportionate viewport real estate.
+- Risk: increased scroll fatigue, delayed access to key conversion actions.
+
+4. Horizontal scroll reliance for critical interactions
+
+- Symptom: essential controls/content require horizontal scrolling in narrow viewports.
+- Risk: poor usability, lower completion rates, accessibility friction.
+
+5. Viewport misconfiguration
+
+- Symptom: missing or overridden viewport behavior causing incorrect scaling.
+- Risk: rendering and usability regressions on mobile; reflow failures.
+
+## Repo Hotspot Map (Current Evidence)
+
+1. `/Users/fabiencampana/Documents/imageforge-site/components/landing/HeaderNav.tsx`
+
+- Evidence: desktop nav group is hidden on smaller breakpoints (`hidden ... md:flex`) with no explicit mobile menu component.
+- Risk theme: mobile navigation discoverability and internal-link parity.
+
+2. `/Users/fabiencampana/Documents/imageforge-site/components/landing/ComparisonAndCost.tsx`
+
+- Evidence: desktop table branch (`hidden ... md:block`) and separate mobile card branch (`md:hidden`).
+- Risk theme: duplicated markup drift between responsive variants.
+
+3. `/Users/fabiencampana/Documents/imageforge-site/components/landing/TerminalDemo.tsx`
+
+- Evidence: `min-h-[420px]` plus animated incremental content.
+- Risk theme: small-screen content density and delayed access to downstream sections.
+
+4. `/Users/fabiencampana/Documents/imageforge-site/components/landing/InstallCommands.tsx`
+
+- Evidence: tablist and command surfaces use `overflow-x-auto`.
+- Risk theme: horizontal interaction dependence in narrow viewports.
+
+5. `/Users/fabiencampana/Documents/imageforge-site/components/landing/CopyButton.tsx`
+
+- Evidence: button uses `h-8` (32 CSS px height).
+- Risk theme: touch target minimum risk if effective tap area remains below recommended minimum dimensions with spacing context.
+
+6. `/Users/fabiencampana/Documents/imageforge-site/app/globals.css`
+
+- Evidence: global layers/gradients/animations and terminal cursor animation handling.
+- Risk theme: paint cost, motion adaptation, and global responsive side effects.
+
+## Standard Audit Command Set
+
+Use this command sequence during future responsive assessments:
+
+```bash
+pnpm lint
+pnpm typecheck
+NEXT_PUBLIC_SITE_URL=https://example.com pnpm build
+NEXT_PUBLIC_SITE_URL=https://example.com pnpm seo:full -- --mode advisory
+```
+
+## Prioritization Rules for Implementation
+
+Apply this order when selecting what to fix first:
+
+1. User-impact blockers
+
+- Broken or degraded task completion at common mobile widths
+- Severe discoverability or interaction failures
+
+2. SEO discoverability risks
+
+- Crawl path/content parity issues tied to responsive branches
+- Hidden links/content in mobile variants
+
+3. Performance regressions
+
+- CWV risk from responsive media/layout/motion behavior
+
+Tie-breakers:
+
+1. Prefer fixes that reduce duplicated markup branches.
+2. Prefer fixes that improve both accessibility and SEO parity simultaneously.
+3. Prefer low-regression changes that do not alter core product messaging.
+
+## Assumptions and Defaults
+
+- Advisory-first scoring for the first responsive audit cycle.
+- Landing-focused scope only.
+- No code implementation changes in this research phase.
+- Responsive-width semantics remain anchored to:
+  `/Users/fabiencampana/Documents/ImageForge/docs/product/responsive-widths-contract.md`
+
+## Sources
+
+1. [Google Search Central: Mobile-first indexing best practices](https://developers.google.com/search/docs/crawling-indexing/mobile/mobile-first-indexing)
+2. [Google Search Central: Fix lazy-loaded content issues](https://developers.google.com/search/docs/crawling-indexing/javascript/lazy-loading)
+3. [web.dev: Responsive web design basics](https://web.dev/articles/responsive-web-design-basics)
+4. [web.dev: Core Web Vitals](https://web.dev/articles/cwv)
+5. [MDN: Responsive images](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images)
+6. [MDN: HTML `sizes` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Responsive_images)
+7. [MDN: `viewport` meta element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport)
+8. [MDN: `prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+9. [MDN: `@media (pointer)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer)
+10. [W3C WCAG 2.2 Understanding: Reflow (1.4.10)](https://www.w3.org/WAI/WCAG22/Understanding/reflow)
+11. [W3C WCAG 2.2 Understanding: Target Size (Minimum) (2.5.8)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum)
+12. [Next.js: Image component](https://nextjs.org/docs/pages/api-reference/components/image)
+13. [Next.js: generateViewport (default viewport behavior)](https://nextjs.org/docs/app/api-reference/functions/generate-viewport)
+
+## Interpretation Notes
+
+Some prioritization and ranking guidance in this document are engineering inferences derived from the linked primary sources and current repository constraints; they are not direct normative text from a single standard.

--- a/docs/responsive-agent/landing-responsive-risk-register.md
+++ b/docs/responsive-agent/landing-responsive-risk-register.md
@@ -1,0 +1,31 @@
+# Landing Responsive Risk Register
+
+Date: 2026-02-13
+Scope: Landing-focused (`/` and `/components/landing/*`)
+Status model: Advisory-only (cycle 1)
+
+## Usage
+
+- This register tracks baseline responsive risks discovered through static analysis before implementation work.
+- Every row is advisory in cycle 1, including `critical` severity rows.
+- Severity and confidence scoring must follow:
+  `/Users/fabiencampana/Documents/imageforge-site/.codex/skills/responsive-agent/references/severity-rubric.md`
+
+## Baseline Issues
+
+| id                     | area                              | viewport_range                   | severity | confidence | evidence                                                                                                                                                                                                                    | impact                                                                                                                 | recommended_direction                                                                                  | validation                                                                                                                                                  |
+| ---------------------- | --------------------------------- | -------------------------------- | -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resp-nav-001`         | navigation discoverability        | `< md` (`320-767`)               | high     | 0.86       | `/Users/fabiencampana/Documents/imageforge-site/components/landing/HeaderNav.tsx` hides primary section links via `hidden ... md:flex`; no dedicated mobile menu pattern present.                                           | Mobile users may miss key section pathways; reduced internal-link discovery and weaker conversion flow.                | Add explicit mobile navigation pattern that preserves section-link parity and keyboard/touch access.   | Check at 320/360/375/390/412 widths in portrait and landscape; verify all key section links reachable by keyboard and touch without horizontal page scroll. |
+| `resp-content-001`     | content parity drift              | split at `md`                    | medium   | 0.88       | `/Users/fabiencampana/Documents/imageforge-site/components/landing/ComparisonAndCost.tsx` renders separate table (`md:block`) and card (`md:hidden`) markup branches.                                                       | Separate branches can diverge in copy, sources, or links over time, creating SEO and trust inconsistency.              | Unify shared content source and enforce parity checks between table/card variants.                     | Compare mobile and desktop rendered text/links/source references for each row; confirm factual parity after updates.                                        |
+| `resp-layout-001`      | viewport density                  | `< md` (`320-767`)               | medium   | 0.82       | `/Users/fabiencampana/Documents/imageforge-site/components/landing/TerminalDemo.tsx` uses `min-h-[420px]` and animated line reveal.                                                                                         | Above-the-fold scroll budget can be consumed on smaller screens, delaying access to conversion actions below the hero. | Use adaptive min-height rules and/or condensed mobile rendering while preserving meaning.              | Verify first-scroll experience on 320/360 widths; confirm downstream section discovery without excessive scrolling and without causing CLS.                 |
+| `resp-interaction-001` | horizontal interaction dependence | `< md` (`320-767`)               | medium   | 0.84       | `/Users/fabiencampana/Documents/imageforge-site/components/landing/InstallCommands.tsx` and `/Users/fabiencampana/Documents/imageforge-site/components/landing/CodeBlock.tsx` rely on `overflow-x-auto` for key command UI. | Users may need horizontal panning to access controls/content, increasing friction and reducing completion.             | Rework narrow-width layout to minimize horizontal scrolling for critical actions and labels.           | Test command tablist and code surfaces at 320-412 widths; verify primary actions usable without required horizontal panning.                                |
+| `resp-a11y-001`        | touch target sizing               | all (height-sensitive on mobile) | medium   | 0.79       | `/Users/fabiencampana/Documents/imageforge-site/components/landing/CopyButton.tsx` sets `h-8` (32px) and compact horizontal padding.                                                                                        | Tap accuracy may degrade depending on spacing context and adjacent controls, especially for coarse pointer input.      | Increase effective target area to align with WCAG 2.2 minimum target-size guidance and verify spacing. | Validate with emulated coarse pointer and real-device tap checks; confirm target dimensions and no overlap/focus ambiguity.                                 |
+
+## Operating Notes
+
+1. Advisory-only behavior means no automatic merge blocking from this register in cycle 1.
+2. Fix sequencing should follow:
+   1. user-impact blockers
+   2. SEO discoverability risks
+   3. performance regression risks
+3. Convert to hard-gate mode only after one full audit + remediation loop validates metric stability.


### PR DESCRIPTION
## Summary
- Add a repository-local responsive-agent Codex skill with checklist, severity rubric, and output contract.
- Add landing responsive reference documentation and risk register for future audits.

## Validation
- git diff --check main...HEAD
- pnpm lint && pnpm typecheck && pnpm build
